### PR TITLE
Add `HASSIO_` prefix back to `DECONZ_OPTS` values

### DIFF
--- a/amd64-hassio-addon/run.sh
+++ b/amd64-hassio-addon/run.sh
@@ -16,13 +16,13 @@ HASSIO_DECONZ_VNC_PORT="$(jq --raw-output '.vnc.port' $CONFIG_PATH)"
 HASSIO_DECONZ_VNC_PASSWORD="$(jq --raw-output '.vnc.password' $CONFIG_PATH)"
 
 DECONZ_OPTS="--auto-connect=1 \
-        --dbg-info=$DEBUG_INFO \
-        --dbg-aps=$DEBUG_APS \
-        --dbg-zcl=$DEBUG_ZCL \
-        --dbg-zdp=$DEBUG_ZDP \
-        --dbg-otau=$DEBUG_OTAU \
-        --http-port=$DECONZ_WEB_PORT \
-        --ws-port=$DECONZ_WS_PORT"
+        --dbg-info=$HASSIO_DEBUG_INFO \
+        --dbg-aps=$HASSIO_DEBUG_APS \
+        --dbg-zcl=$HASSIO_DEBUG_ZCL \
+        --dbg-zdp=$HASSIO_DEBUG_ZDP \
+        --dbg-otau=$HASSIO_DEBUG_OTAU \
+        --http-port=$HASSIO_DECONZ_WEB_PORT \
+        --ws-port=$HASSIO_DECONZ_WS_PORT"
 
 echo "[Hass.io] Starting deCONZ Hass.io Addon..."
 echo "[Hass.io] Current deCONZ version: $DECONZ_VERSION"
@@ -39,8 +39,8 @@ if [ "$HASSIO_DECONZ_VNC_MODE" = "true" ]; then
   chmod 600 /data/.vnc/passwd
 
   # Not necessary on hassio to delete old pid file
-  # tigervncserver -kill "$DECONZ_VNC_DISPLAY" 
-  
+  # tigervncserver -kill "$DECONZ_VNC_DISPLAY"
+
   tigervncserver -SecurityTypes VncAuth,TLSVnc $HASSIO_DECONZ_VNC_DISPLAY
   export DISPLAY=$HASSIO_DECONZ_VNC_DISPLAY
 else
@@ -50,5 +50,5 @@ fi
 
 export USER=root
 
-/usr/bin/deCONZ $DECONZ_OPTS 
-    
+/usr/bin/deCONZ $DECONZ_OPTS
+

--- a/armhf-hassio-addon/run.sh
+++ b/armhf-hassio-addon/run.sh
@@ -16,13 +16,13 @@ HASSIO_DECONZ_VNC_PORT="$(jq --raw-output '.vnc.port' $CONFIG_PATH)"
 HASSIO_DECONZ_VNC_PASSWORD="$(jq --raw-output '.vnc.password' $CONFIG_PATH)"
 
 DECONZ_OPTS="--auto-connect=1 \
-        --dbg-info=$DEBUG_INFO \
-        --dbg-aps=$DEBUG_APS \
-        --dbg-zcl=$DEBUG_ZCL \
-        --dbg-zdp=$DEBUG_ZDP \
-        --dbg-otau=$DEBUG_OTAU \
-        --http-port=$DECONZ_WEB_PORT \
-        --ws-port=$DECONZ_WS_PORT"
+        --dbg-info=$HASSIO_DEBUG_INFO \
+        --dbg-aps=$HASSIO_DEBUG_APS \
+        --dbg-zcl=$HASSIO_DEBUG_ZCL \
+        --dbg-zdp=$HASSIO_DEBUG_ZDP \
+        --dbg-otau=$HASSIO_DEBUG_OTAU \
+        --http-port=$HASSIO_DECONZ_WEB_PORT \
+        --ws-port=$HASSIO_DECONZ_WS_PORT"
 
 echo "[Hass.io] Starting deCONZ Hass.io Addon..."
 echo "[Hass.io] Current deCONZ version: $DECONZ_VERSION"
@@ -39,8 +39,8 @@ if [ "$HASSIO_DECONZ_VNC_MODE" = "true" ]; then
   chmod 600 /data/.vnc/passwd
 
   # Not necessary on hassio to delete old pid file
-  # tigervncserver -kill "$DECONZ_VNC_DISPLAY" 
-  
+  # tigervncserver -kill "$DECONZ_VNC_DISPLAY"
+
   tigervncserver -SecurityTypes VncAuth,TLSVnc $HASSIO_DECONZ_VNC_DISPLAY
   export DISPLAY=$HASSIO_DECONZ_VNC_DISPLAY
 else
@@ -50,5 +50,5 @@ fi
 
 export USER=root
 
-/usr/bin/deCONZ $DECONZ_OPTS 
+/usr/bin/deCONZ $DECONZ_OPTS
 


### PR DESCRIPTION
This was inadvertently removed in marthoc/docker-deconz#88

Signed-off-by: Seth Chisamore <schisamo@chef.io>