### PR TITLE
Bugfix

### DIFF
--- a/aarch64/root/start.sh
+++ b/aarch64/root/start.sh
@@ -15,8 +15,13 @@ DECONZ_OPTS="--auto-connect=1 \
         --ws-port=$DECONZ_WS_PORT"
 
 if [ "$DECONZ_VNC_MODE" != 0 ]; then
+  
+  if [ "$DECONZ_VNC_PORT" -lt 5900 ]; then
+    echo "[marthoc/deconz] ERROR - VNC port must be 5900 or greater!"
+    exit 1
+  fi
 
-  DECONZ_VNC_DISPLAY=:0
+  DECONZ_VNC_DISPLAY=:$(($DECONZ_VNC_PORT - 5900))
   echo "[marthoc/deconz] VNC port: $DECONZ_VNC_PORT"
   
   if [ ! -e /root/.vnc ]; then

--- a/amd64/root/start.sh
+++ b/amd64/root/start.sh
@@ -15,8 +15,13 @@ DECONZ_OPTS="--auto-connect=1 \
         --ws-port=$DECONZ_WS_PORT"
 
 if [ "$DECONZ_VNC_MODE" != 0 ]; then
+  
+  if [ "$DECONZ_VNC_PORT" -lt 5900 ]; then
+    echo "[marthoc/deconz] ERROR - VNC port must be 5900 or greater!"
+    exit 1
+  fi
 
-  DECONZ_VNC_DISPLAY=:0
+  DECONZ_VNC_DISPLAY=:$(($DECONZ_VNC_PORT - 5900))
   echo "[marthoc/deconz] VNC port: $DECONZ_VNC_PORT"
   
   if [ ! -e /root/.vnc ]; then

--- a/armhf/root/start.sh
+++ b/armhf/root/start.sh
@@ -15,8 +15,13 @@ DECONZ_OPTS="--auto-connect=1 \
         --ws-port=$DECONZ_WS_PORT"
 
 if [ "$DECONZ_VNC_MODE" != 0 ]; then
+  
+  if [ "$DECONZ_VNC_PORT" -lt 5900 ]; then
+    echo "[marthoc/deconz] ERROR - VNC port must be 5900 or greater!"
+    exit 1
+  fi
 
-  DECONZ_VNC_DISPLAY=:0
+  DECONZ_VNC_DISPLAY=:$(($DECONZ_VNC_PORT - 5900))
   echo "[marthoc/deconz] VNC port: $DECONZ_VNC_PORT"
   
   if [ ! -e /root/.vnc ]; then


### PR DESCRIPTION
Previous update inadvertently disabled the ability to set change the VNC port to a port other than 5900; this functionality is now restored.