### PR TITLE
New deconz.dresden-elektronik.de subdomain

### DIFF
--- a/aarch64/Dockerfile
+++ b/aarch64/Dockerfile
@@ -50,7 +50,7 @@ RUN chmod +x /tini && \
     chmod +x /firmware-update.sh
 
 # Add deCONZ, install deCONZ, make OTAU dir
-ADD https://www.dresden-elektronik.de/rpi/deconz/alpha/deconz_${DECONZ_VERSION}-debian-stretch-beta_arm64.deb /deconz.deb
+ADD http://deconz.dresden-elektronik.de/raspbian/alpha/deconz_${DECONZ_VERSION}-debian-stretch-beta_arm64.deb /deconz.deb
 RUN dpkg -i /deconz.deb && \
     rm -f /deconz.deb && \
     mkdir /root/otau && \

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -50,7 +50,7 @@ RUN chmod +x /tini && \
     chmod +x /firmware-update.sh
 
 # Add deCONZ, install deCONZ, make OTAU dir
-ADD https://www.dresden-elektronik.de/deconz/ubuntu/beta/deconz-${DECONZ_VERSION}-qt5.deb /deconz.deb
+ADD http://deconz.dresden-elektronik.de/ubuntu/beta/deconz-${DECONZ_VERSION}-qt5.deb /deconz.deb
 RUN dpkg -i /deconz.deb && \
     rm -f /deconz.deb && \
     mkdir /root/otau && \

--- a/armhf/Dockerfile
+++ b/armhf/Dockerfile
@@ -55,7 +55,7 @@ RUN chmod +x /tini && \
     chmod +x /firmware-update.sh
 
 # Add deCONZ, install deCONZ, make OTAU dir
-ADD https://www.dresden-elektronik.de/rpi/deconz/beta/deconz-${DECONZ_VERSION}-qt5.deb /deconz.deb
+ADD http://deconz.dresden-elektronik.de/raspbian/beta/deconz-${DECONZ_VERSION}-qt5.deb /deconz.deb
 RUN dpkg -i /deconz.deb && \
     rm -f /deconz.deb && \
     mkdir /root/otau && \


### PR DESCRIPTION
Due a new website on dresden-elektronik.de, the old paths might not work for some time.
The redirection of links should be active very soon.

This PR uses the `deconz.` subdomain to fix the 404.