### PR TITLE
Change base image to Debian

### DIFF
--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -5,7 +5,8 @@ ARG VERSION
 ARG CHANNEL
 
 # Runtime environment variables
-ENV DECONZ_VERSION=${VERSION} \
+ENV DEBIAN_FRONTEND=noninteractive \
+    DECONZ_VERSION=${VERSION} \
     DECONZ_WEB_PORT=80 \
     DECONZ_WS_PORT=443 \
     DEBUG_INFO=1 \

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/amd64-debian:stretch-run
+FROM debian:10.6-slim
 
 # Build arguments
 ARG VERSION
@@ -40,15 +40,6 @@ RUN apt-get update && \
         wmii \
         xfonts-base \
         xfonts-scalable && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# WORKAROUND: update libc6 so flashing script works
-# This can be removed when the base image includes GLIBC >= 2.28
-RUN echo "deb http://ftp.us.debian.org/debian sid main" >> /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get install --only-upgrade -y -o APT::Immediate-Configure=false \
-        libc6 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/arm64/Dockerfile
+++ b/arm64/Dockerfile
@@ -1,4 +1,6 @@
+FROM multiarch/qemu-user-static:aarch64 as qemu
 FROM arm64v8/debian:10.6-slim
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 
 # Build arguments
 ARG VERSION

--- a/arm64/Dockerfile
+++ b/arm64/Dockerfile
@@ -7,7 +7,8 @@ ARG VERSION
 ARG CHANNEL
 
 # Runtime environment variables
-ENV DECONZ_VERSION=${VERSION} \
+ENV DEBIAN_FRONTEND=noninteractive \
+    DECONZ_VERSION=${VERSION} \
     DECONZ_WEB_PORT=80 \
     DECONZ_WS_PORT=443 \
     DEBUG_INFO=1 \

--- a/arm64/Dockerfile
+++ b/arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/aarch64-debian:stretch-run
+FROM arm64v8/debian:10.6-slim
 
 # Build arguments
 ARG VERSION
@@ -40,15 +40,6 @@ RUN apt-get update && \
         wmii \
         xfonts-base \
         xfonts-scalable && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# WORKAROUND: update libc6 so flashing script works
-# This can be removed when the base image includes GLIBC >= 2.28
-RUN echo "deb http://ftp.us.debian.org/debian sid main" >> /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get install --only-upgrade -y -o APT::Immediate-Configure=false \
-        libc6 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/armv7/Dockerfile
+++ b/armv7/Dockerfile
@@ -7,7 +7,8 @@ ARG VERSION
 ARG CHANNEL
 
 # Runtime environment variables
-ENV DECONZ_VERSION=${VERSION} \
+ENV DEBIAN_FRONTEND=noninteracive \
+    DECONZ_VERSION=${VERSION} \
     DECONZ_WEB_PORT=80 \
     DECONZ_WS_PORT=443 \
     DEBUG_INFO=1 \

--- a/armv7/Dockerfile
+++ b/armv7/Dockerfile
@@ -1,4 +1,6 @@
+FROM multiarch/qemu-user-static:arm as qemu
 FROM arm32v7/debian:10.6-slim
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
 
 # Build arguments
 ARG VERSION

--- a/armv7/Dockerfile
+++ b/armv7/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/armv7hf-debian:stretch-run
+FROM arm32v7/debian:10.6-slim
 
 # Build arguments
 ARG VERSION
@@ -47,15 +47,6 @@ RUN apt-get update && \
 ADD https://project-downloads.drogon.net/wiringpi-latest.deb /wiringpi.deb
 RUN dpkg -i /wiringpi.deb && \
     rm -f /wiringpi.deb
-
-# WORKAROUND: update libc6 so flashing script works
-# This can be removed when the base image includes GLIBC >= 2.28
-RUN echo "deb http://ftp.us.debian.org/debian sid main" >> /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get install --only-upgrade -y -o APT::Immediate-Configure=false \
-        libc6 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
 
 # Add start.sh and Conbee udev data; set execute permissions
 COPY root /


### PR DESCRIPTION
Using the Balenalib images has led to some difficult to track issues with UDEV - changing to a clean, slim base image to remove potential sources of malfunction.

Closes #246. Closes #228. Closes #236.