### PR TITLE
add timeout for flashing

### DIFF
--- a/amd64/root/firmware-update.sh
+++ b/amd64/root/firmware-update.sh
@@ -94,7 +94,7 @@ echo " "
 if [[ $correctVal == [yY] ]]; then
         echo "Flashing..."
         echo " "
-        $FLASHER -d $deviceName -f "$filePath"
+        $FLASHER -t 60 -d $deviceName -f "$filePath"
 
         retVal=$?
         if (( retVal != 0 )); then

--- a/arm64/root/firmware-update.sh
+++ b/arm64/root/firmware-update.sh
@@ -94,7 +94,7 @@ echo " "
 if [[ $correctVal == [yY] ]]; then
         echo "Flashing..."
         echo " "
-        $FLASHER -d $deviceName -f "$filePath"
+        $FLASHER -t 60 -d $deviceName -f "$filePath"
 
         retVal=$?
         if (( retVal != 0 )); then

--- a/armv7/root/firmware-update.sh
+++ b/armv7/root/firmware-update.sh
@@ -94,7 +94,7 @@ echo " "
 if [[ $correctVal == [yY] ]]; then
         echo "Flashing..."
         echo " "
-        $FLASHER -d $deviceName -f "$filePath"
+        $FLASHER -t 60 -d $deviceName -f "$filePath"
 
         retVal=$?
         if (( retVal != 0 )); then


### PR DESCRIPTION
Flashing a new firmware should have the recommended timeout value (https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Update-deCONZ-manually).

In case you had an issue while updating (like ModemManager kicking in) you cannot revive the stick without the timeout value.