### PR TITLE
Added install requisite Wiring Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ sudo usermod -a -G dialout $USER
 
 For a RaspBee/Raspbee 2 installation on a Raspberry PI 4B : Make sure to have Wiring Pi updated to the latest version!
 ```
- cd /tmp
- wget https://project-downloads.drogon.net/wiringpi-latest.deb
- sudo dpkg -i wiringpi-latest.deb
+sudo apt install wiringpi
 ``` 
 #### Command Line
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,18 @@ Please consult Docker Hub for the latest available versions of this image.
 
 #### Pre-requisite
 
-Before running the command that creates the deconz Docker container, you may need to add your Linux user to the `dialout` group, which allows the user access to serial devices (i.e. Conbee/Conbee II/RaspBee):
+Before running the command that creates the deconz Docker container, you may need to add your Linux user to the `dialout` group, which allows the user access to serial devices (i.e. Conbee/Conbee II/RaspBee/RaspBeeII):
 
 ```bash
 sudo usermod -a -G dialout $USER
 ```
 
+For a RaspBee/Raspbee 2 installation on a Raspberry PI 4B : Make sure to have Wiring Pi updated to the latest version!
+```
+ cd /tmp
+ wget https://project-downloads.drogon.net/wiringpi-latest.deb
+ sudo dpkg -i wiringpi-latest.deb
+``` 
 #### Command Line
 
 ```bash


### PR DESCRIPTION
On RPI 4B, you need WiringPI installed on the host. Added that to the read-me.