### PR TITLE
Adding Environment DECONZ_VNC_OPTS allowing e.g. VNC geometry changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Use these environment variables to change the default behaviour of the container
 |`-e DECONZ_VNC_MODE=1`|Set this option to enable VNC access to the container to view the deCONZ ZigBee mesh|
 |`-e DECONZ_VNC_PORT=5900`|Default port for VNC mode is 5900; this option can be used to change this port|
 |`-e DECONZ_VNC_PASSWORD=changeme`|Default password for VNC mode is 'changeme'; this option can (should) be used to change the default password|
-|`-e DECONZ_VNC_OPTS="-g 1280x900"`|Pass more options to the VNC server, e.g. -g changes the screen resolution|
+|`-e DECONZ_VNC_OPTS="-g 1280x900"`|Pass more options to the VNC server. Example: -g changes the screen resolution|
 |`-e DECONZ_UPNP=0`|Set this option to 0 to disable uPNP, see: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/274|
 
 #### Docker-Compose

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Use these environment variables to change the default behaviour of the container
 |`-e DECONZ_VNC_MODE=1`|Set this option to enable VNC access to the container to view the deCONZ ZigBee mesh|
 |`-e DECONZ_VNC_PORT=5900`|Default port for VNC mode is 5900; this option can be used to change this port|
 |`-e DECONZ_VNC_PASSWORD=changeme`|Default password for VNC mode is 'changeme'; this option can (should) be used to change the default password|
+|`-e DECONZ_VNC_OPTS="-g 1280x900"`|Pass more options to the VNC server, e.g. -g changes the screen resolution|
 |`-e DECONZ_UPNP=0`|Set this option to 0 to disable uPNP, see: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/274|
 
 #### Docker-Compose

--- a/amd64/root/start.sh
+++ b/amd64/root/start.sh
@@ -36,7 +36,7 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
   tigervncserver -kill "$DECONZ_VNC_DISPLAY"
 
   # Set VNC security
-  tigervncserver -SecurityTypes VncAuth,TLSVnc "$DECONZ_VNC_DISPLAY"
+  tigervncserver $DECONZ_VNC_OPTS -SecurityTypes VncAuth,TLSVnc "$DECONZ_VNC_DISPLAY"
   
   # Export VNC display variable
   export DISPLAY=$DECONZ_VNC_DISPLAY

--- a/arm64/root/start.sh
+++ b/arm64/root/start.sh
@@ -36,7 +36,7 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
   tigervncserver -kill "$DECONZ_VNC_DISPLAY"
 
   # Set VNC security
-  tigervncserver -SecurityTypes VncAuth,TLSVnc "$DECONZ_VNC_DISPLAY"
+  tigervncserver $DECONZ_VNC_OPTS -SecurityTypes VncAuth,TLSVnc "$DECONZ_VNC_DISPLAY"
   
   # Export VNC display variable
   export DISPLAY=$DECONZ_VNC_DISPLAY

--- a/armv7/root/start.sh
+++ b/armv7/root/start.sh
@@ -36,7 +36,7 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
   tigervncserver -kill "$DECONZ_VNC_DISPLAY"
 
   # Set VNC security
-  tigervncserver -SecurityTypes VncAuth,TLSVnc "$DECONZ_VNC_DISPLAY"
+  tigervncserver $DECONZ_VNC_OPTS -SecurityTypes VncAuth,TLSVnc "$DECONZ_VNC_DISPLAY"
   
   # Export VNC display variable
   export DISPLAY=$DECONZ_VNC_DISPLAY


### PR DESCRIPTION
The geometry of the VNC screen is quite huge, so reading anything on a laptop screen is a pain. 
Add  -e DECONZ_VNC_OPTS="-g 1280x900" and customize as needed. In fact any VNC option may be added.
Leaving empty uses default geometry.