### PR TITLE
Options for GCFFlasher

### DIFF
--- a/amd64/root/firmware-update.sh
+++ b/amd64/root/firmware-update.sh
@@ -1,9 +1,63 @@
 #!/bin/bash
 
-VERSION=0.6
+# ===========================
+# Configuration
+# ===========================
+VERSION=0.7
 FLASHER=/usr/bin/GCFFlasher_internal
 FW_PATH=/usr/share/deCONZ/firmware/
-FW_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+
+# ===========================
+# exit functions
+# ===========================
+# ---------------------------
+# Exit the script
+# - on exit print 1st param or "Exiting..." as message
+# - use 2nd param or 1 as exit-code
+# ---------------------------
+function exit_with_error() {
+    typeset msg="${1:-Exiting...}"
+    typeset -i retVal="${2:-1}"
+    printf "\n%s\n\n" "$msg"
+    exit $retVal
+}
+
+# ---------------------------
+# Check last return-code or 2nd param
+# - if non-zero exit with message
+# - on exit print 1st param or "Exiting..." as message
+# ---------------------------
+function exit_on_error() {
+    typeset msg="$1"
+    typeset -i retVal="${2:-$?}"
+    (( retVal == 0 )) || exit_with_error "$msg" $retVal
+}
+
+# ---------------------------
+# Check last return-code or 3rd param
+# - if non-zero exit with message
+# - on exit remove file (1st param) if present
+# - on exit print 2nd param or "Exiting..." as message
+# ---------------------------
+function delete_and_exit_on_error() {
+    typeset file="$1"
+    typeset msg="$2"
+    typeset -i retVal="${2:-$?}"
+    if (( retVal != 0 )); then
+        [[ -f $file ]] && rm "$file"
+        exit_with_error "$msg" $retVal
+    fi
+}
+
+# ---------------------------
+# Check 1st param as user-input
+# - exit script on empty input
+# ---------------------------
+function exit_on_enter() {
+    typeset input="$1"
+    [[ -n $input ]] || exit_with_error
+}
 
 echo "-------------------------------------------------------------------"
 echo " "
@@ -22,13 +76,11 @@ $FLASHER -l
 echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
-read -p "Device Path : " deviceName
-echo " "
-if [[ -z "${deviceName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 
+read -p "Device path : " deviceName
+exit_on_enter $deviceName
+
+echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 echo "Firmware available for flashing:"
@@ -37,74 +89,44 @@ ls -1 "$FW_PATH"
 echo " "
 echo "Enter the firmware file name from above, including extension."
 echo "Alternatively, you may enter the name of a firmware file to download"
-echo "from $FW_BASE"
+echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
 read -p "File Name : " fileName
+exit_on_enter $fileName
 echo " "
-if [[ -z "${fileName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 filePath="${FW_PATH%/}/$fileName"
 if [[ ! -f $filePath ]]; then
-        echo "File not found locally. Try to download?"
-        read -p "Enter Y to proceed, any other entry to exit: " answer
-        echo " "
-        if [[ $answer != [yY] ]]; then
-                echo "Exiting..."
-                exit 1
-        fi
-        echo "Downloading..."
-        echo " "
-        curl --fail --output "$filePath" "${FW_BASE%/}/$fileName"
-        retVal=$?
-        if [[ ! -f $filePath ]] || (( retVal != 0 )); then
-                echo " "
-                echo "Download Error! Please re-run this script..."
-                echo " "
-                [[ -f $filePath ]] && rm "$filePath"
-                exit $(( retVal == 0 ? 1 : retVal ))
-        fi
-        echo " "
-        echo "Download complete! Checking md5 checksum..."
-        md5=$(curl --fail --silent "${FW_BASE%/}/${fileName}.md5")
-        echo "${md5% *} ${filePath}" | md5sum --check
-        retVal=$?
-        echo " "
-        if (( retVal != 0 )); then
-                echo "Error comparing checksums! Please re-run this script..."
-                echo " "
-                rm "$filePath"
-                exit $retVal
-        fi
+    echo "File not found locally. Try to download?"
+    read -p "Enter Y to proceed, any other entry to exit: " answer
+    [[ $answer == [yY] ]] || exit_with_error
+
+    echo " "
+    echo "Downloading..."
+    echo " "
+    curl --fail --output "$filePath" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f $filePath ]]
+    delete_and_exit_on_error "$filePath" "Download Error! Please re-run this script..."
+    echo " "
+    echo "Download complete! Checking md5 checksum..."
+    md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
+    [[ -z $md5 ]] || delete_and_exit_on_error "$filePath" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${filePath}" | md5sum --check
+    delete_and_exit_on_error "$filePath" "Error comparing checksums! Please re-run this script..."
+    echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device: $deviceName"
-echo " "
+echo "Device ......: $deviceName"
 echo "Firmware File: $fileName"
 echo " "
 echo "Are the above device and firmware values correct?"
 read -p "Enter Y to proceed, any other entry to exit: " correctVal
+[[ $correctVal == [yY] ]] || exit_with_error
+
 echo " "
-
-if [[ $correctVal == [yY] ]]; then
-        echo "Flashing..."
-        echo " "
-        $FLASHER -t 60 -d $deviceName -f "$filePath"
-
-        retVal=$?
-        if (( retVal != 0 )); then
-                echo " "
-                echo "Flashing Error! Please re-run this script..."
-                echo " "
-                exit $retVal
-        fi
-else
-        echo "Exiting..."
-        echo " "
-        exit 1
-fi
+echo "Flashing..."
+echo " "
+$FLASHER -d $deviceName -f "$filePath"
+exit_on_error "Flashing Error! Please re-run this script..."

--- a/amd64/root/firmware-update.sh
+++ b/amd64/root/firmware-update.sh
@@ -4,7 +4,37 @@
 # Configuration
 # ===========================
 VERSION=0.7
+# ---------------------------
+# Flasher and options
+# ---------------------------
 FLASHER=/usr/bin/GCFFlasher_internal
+FLASHER_PARAM_LIST=( -d -f -s -t -R -B -x )
+typeset -A FLASHER_PARAM_NAMES=( # GCFFlasher <options>
+                                 #  -r              force device reset without programming
+    [-f]="Firmware file"         #  -f <firmware>   flash firmware file
+    [-d]="Device path ."         #  -d <device>     device number or path to use, e.g. 0, /dev/ttyUSB0 or RaspBee
+    [-s]="Serial number"         #  -s <serial>     serial number to use
+    [-t]="Timeout ....."         #  -t <timeout>    retry until timeout (seconds) is reached
+    [-R]="Retries ....."         #  -R <retries>    max. retries
+    [-B]="Baudrate ...."         #  -B <baudrate>   custom baudrate
+                                 #  -l              list devices
+    [-x]="Loglevel ...."         #  -x <loglevel>   debug log level 0, 1, 3
+                                 #  -j <test>       runs a test 1
+                                 #  -h -?           print this help
+)
+typeset -A FLASHER_PARAM_PRINT=(
+    [-f]="[^/]*$"
+    [default]=".*"
+)
+# Default values
+typeset -A FLASHER_PARAM_VALUES=(
+    [-d]="$DECONZ_DEVICE"
+    [-t]="30"
+)
+
+# ---------------------------
+# Firmware details
+# ---------------------------
 FW_PATH=/usr/share/deCONZ/firmware/
 FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
 
@@ -59,6 +89,21 @@ function exit_on_enter() {
     [[ -n $input ]] || exit_with_error
 }
 
+# ===========================
+# utility functions
+# ===========================
+# ---------------------------
+# Parse all options passed to the script.
+# Options of the flasher are valid options.
+# ---------------------------
+function parse_options() {
+    while (( $# > 0)); do
+        [[ -n ${FLASHER_PARAM_NAMES[$1]} ]] || exit_with_error "Unknown argument '$1'. Exiting ..."
+        FLASHER_PARAM_VALUES[$1]="$2"
+        shift 2
+    done
+}
+
 echo "-------------------------------------------------------------------"
 echo " "
 echo "             marthoc/deconz Firmware Flashing Script"
@@ -67,6 +112,9 @@ echo "                       Version: $VERSION"
 echo " "
 echo "-------------------------------------------------------------------"
 echo " "
+
+parse_options
+
 echo " "
 echo "Listing attached devices..."
 echo " "
@@ -77,8 +125,8 @@ echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
 
-read -p "Device path : " deviceName
-exit_on_enter $deviceName
+read -ep "Device path : " -i "${FLASHER_PARAM_VALUES[-d]}" FLASHER_PARAM_VALUES[-d]
+exit_on_enter ${FLASHER_PARAM_VALUES[-d]}
 
 echo " "
 echo "-------------------------------------------------------------------"
@@ -93,40 +141,48 @@ echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
-read -p "File Name : " fileName
+read -ep "File Name : " -i "${FLASHER_PARAM_VALUES[-f]##*/}" fileName
 exit_on_enter $fileName
 echo " "
-filePath="${FW_PATH%/}/$fileName"
-if [[ ! -f $filePath ]]; then
+FLASHER_PARAM_VALUES[-f]="${FW_PATH%/}/$fileName"
+if [[ ! -f ${FLASHER_PARAM_VALUES[-f]} ]]; then
     echo "File not found locally. Try to download?"
-    read -p "Enter Y to proceed, any other entry to exit: " answer
+    read -ep "Enter Y to proceed, any other entry to exit: " answer
     [[ $answer == [yY] ]] || exit_with_error
 
     echo " "
     echo "Downloading..."
     echo " "
-    curl --fail --output "$filePath" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f $filePath ]]
-    delete_and_exit_on_error "$filePath" "Download Error! Please re-run this script..."
+    curl --fail --output "${FLASHER_PARAM_VALUES[-f]}" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f ${FLASHER_PARAM_VALUES[-f]} ]]
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Download Error! Please re-run this script..."
     echo " "
     echo "Download complete! Checking md5 checksum..."
     md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
-    [[ -z $md5 ]] || delete_and_exit_on_error "$filePath" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
-    echo "${md5% *} ${filePath}" | md5sum --check
-    delete_and_exit_on_error "$filePath" "Error comparing checksums! Please re-run this script..."
+    [[ -z $md5 ]] || delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${FLASHER_PARAM_VALUES[-f]}" | md5sum --check
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Error comparing checksums! Please re-run this script..."
     echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device ......: $deviceName"
-echo "Firmware File: $fileName"
+FLASHER_PARAMS=()
+for param in "${FLASHER_PARAM_LIST[@]}"; do
+    value="${FLASHER_PARAM_VALUES[$param]}"
+    [[ -n $value ]] || continue
+    FLASHER_PARAMS+=( "$param" "$value" )
+
+    pattern="${FLASHER_PARAM_PRINT[$param]-${FLASHER_PARAM_PRINT[default]}}"
+    [[ $value =~ $pattern ]] && printf "%s: %s\n" "${FLASHER_PARAM_NAMES[$param]}" "${BASH_REMATCH}"
+done
+
 echo " "
-echo "Are the above device and firmware values correct?"
-read -p "Enter Y to proceed, any other entry to exit: " correctVal
+echo "Are the above values correct?"
+read -ep "Enter Y to proceed, any other entry to exit: " correctVal
 [[ $correctVal == [yY] ]] || exit_with_error
 
 echo " "
 echo "Flashing..."
 echo " "
-$FLASHER -d $deviceName -f "$filePath"
+$FLASHER "${FLASHER_PARAMS[@]}"
 exit_on_error "Flashing Error! Please re-run this script..."

--- a/amd64/root/firmware-update.sh
+++ b/amd64/root/firmware-update.sh
@@ -29,7 +29,7 @@ typeset -A FLASHER_PARAM_PRINT=(
 # Default values
 typeset -A FLASHER_PARAM_VALUES=(
     [-d]="$DECONZ_DEVICE"
-    [-t]="30"
+    [-t]="60"
 )
 
 # ---------------------------
@@ -113,7 +113,7 @@ echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 
-parse_options
+parse_options "$@"
 
 echo " "
 echo "Listing attached devices..."

--- a/arm64/root/firmware-update.sh
+++ b/arm64/root/firmware-update.sh
@@ -1,9 +1,63 @@
 #!/bin/bash
 
-VERSION=0.6
+# ===========================
+# Configuration
+# ===========================
+VERSION=0.7
 FLASHER=/usr/bin/GCFFlasher_internal
 FW_PATH=/usr/share/deCONZ/firmware/
-FW_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+
+# ===========================
+# exit functions
+# ===========================
+# ---------------------------
+# Exit the script
+# - on exit print 1st param or "Exiting..." as message
+# - use 2nd param or 1 as exit-code
+# ---------------------------
+function exit_with_error() {
+    typeset msg="${1:-Exiting...}"
+    typeset -i retVal="${2:-1}"
+    printf "\n%s\n\n" "$msg"
+    exit $retVal
+}
+
+# ---------------------------
+# Check last return-code or 2nd param
+# - if non-zero exit with message
+# - on exit print 1st param or "Exiting..." as message
+# ---------------------------
+function exit_on_error() {
+    typeset msg="$1"
+    typeset -i retVal="${2:-$?}"
+    (( retVal == 0 )) || exit_with_error "$msg" $retVal
+}
+
+# ---------------------------
+# Check last return-code or 3rd param
+# - if non-zero exit with message
+# - on exit remove file (1st param) if present
+# - on exit print 2nd param or "Exiting..." as message
+# ---------------------------
+function delete_and_exit_on_error() {
+    typeset file="$1"
+    typeset msg="$2"
+    typeset -i retVal="${2:-$?}"
+    if (( retVal != 0 )); then
+        [[ -f $file ]] && rm "$file"
+        exit_with_error "$msg" $retVal
+    fi
+}
+
+# ---------------------------
+# Check 1st param as user-input
+# - exit script on empty input
+# ---------------------------
+function exit_on_enter() {
+    typeset input="$1"
+    [[ -n $input ]] || exit_with_error
+}
 
 echo "-------------------------------------------------------------------"
 echo " "
@@ -22,13 +76,11 @@ $FLASHER -l
 echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
-read -p "Device Path : " deviceName
-echo " "
-if [[ -z "${deviceName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 
+read -p "Device path : " deviceName
+exit_on_enter $deviceName
+
+echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 echo "Firmware available for flashing:"
@@ -37,74 +89,44 @@ ls -1 "$FW_PATH"
 echo " "
 echo "Enter the firmware file name from above, including extension."
 echo "Alternatively, you may enter the name of a firmware file to download"
-echo "from $FW_BASE"
+echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
 read -p "File Name : " fileName
+exit_on_enter $fileName
 echo " "
-if [[ -z "${fileName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 filePath="${FW_PATH%/}/$fileName"
 if [[ ! -f $filePath ]]; then
-        echo "File not found locally. Try to download?"
-        read -p "Enter Y to proceed, any other entry to exit: " answer
-        echo " "
-        if [[ $answer != [yY] ]]; then
-                echo "Exiting..."
-                exit 1
-        fi
-        echo "Downloading..."
-        echo " "
-        curl --fail --output "$filePath" "${FW_BASE%/}/$fileName"
-        retVal=$?
-        if [[ ! -f $filePath ]] || (( retVal != 0 )); then
-                echo " "
-                echo "Download Error! Please re-run this script..."
-                echo " "
-                [[ -f $filePath ]] && rm "$filePath"
-                exit $(( retVal == 0 ? 1 : retVal ))
-        fi
-        echo " "
-        echo "Download complete! Checking md5 checksum..."
-        md5=$(curl --fail --silent "${FW_BASE%/}/${fileName}.md5")
-        echo "${md5% *} ${filePath}" | md5sum --check
-        retVal=$?
-        echo " "
-        if (( retVal != 0 )); then
-                echo "Error comparing checksums! Please re-run this script..."
-                echo " "
-                rm "$filePath"
-                exit $retVal
-        fi
+    echo "File not found locally. Try to download?"
+    read -p "Enter Y to proceed, any other entry to exit: " answer
+    [[ $answer == [yY] ]] || exit_with_error
+
+    echo " "
+    echo "Downloading..."
+    echo " "
+    curl --fail --output "$filePath" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f $filePath ]]
+    delete_and_exit_on_error "$filePath" "Download Error! Please re-run this script..."
+    echo " "
+    echo "Download complete! Checking md5 checksum..."
+    md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
+    [[ -z $md5 ]] || delete_and_exit_on_error "$filePath" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${filePath}" | md5sum --check
+    delete_and_exit_on_error "$filePath" "Error comparing checksums! Please re-run this script..."
+    echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device: $deviceName"
-echo " "
+echo "Device ......: $deviceName"
 echo "Firmware File: $fileName"
 echo " "
 echo "Are the above device and firmware values correct?"
 read -p "Enter Y to proceed, any other entry to exit: " correctVal
+[[ $correctVal == [yY] ]] || exit_with_error
+
 echo " "
-
-if [[ $correctVal == [yY] ]]; then
-        echo "Flashing..."
-        echo " "
-        $FLASHER -t 60 -d $deviceName -f "$filePath"
-
-        retVal=$?
-        if (( retVal != 0 )); then
-                echo " "
-                echo "Flashing Error! Please re-run this script..."
-                echo " "
-                exit $retVal
-        fi
-else
-        echo "Exiting..."
-        echo " "
-        exit 1
-fi
+echo "Flashing..."
+echo " "
+$FLASHER -d $deviceName -f "$filePath"
+exit_on_error "Flashing Error! Please re-run this script..."

--- a/arm64/root/firmware-update.sh
+++ b/arm64/root/firmware-update.sh
@@ -4,7 +4,37 @@
 # Configuration
 # ===========================
 VERSION=0.7
+# ---------------------------
+# Flasher and options
+# ---------------------------
 FLASHER=/usr/bin/GCFFlasher_internal
+FLASHER_PARAM_LIST=( -d -f -s -t -R -B -x )
+typeset -A FLASHER_PARAM_NAMES=( # GCFFlasher <options>
+                                 #  -r              force device reset without programming
+    [-f]="Firmware file"         #  -f <firmware>   flash firmware file
+    [-d]="Device path ."         #  -d <device>     device number or path to use, e.g. 0, /dev/ttyUSB0 or RaspBee
+    [-s]="Serial number"         #  -s <serial>     serial number to use
+    [-t]="Timeout ....."         #  -t <timeout>    retry until timeout (seconds) is reached
+    [-R]="Retries ....."         #  -R <retries>    max. retries
+    [-B]="Baudrate ...."         #  -B <baudrate>   custom baudrate
+                                 #  -l              list devices
+    [-x]="Loglevel ...."         #  -x <loglevel>   debug log level 0, 1, 3
+                                 #  -j <test>       runs a test 1
+                                 #  -h -?           print this help
+)
+typeset -A FLASHER_PARAM_PRINT=(
+    [-f]="[^/]*$"
+    [default]=".*"
+)
+# Default values
+typeset -A FLASHER_PARAM_VALUES=(
+    [-d]="$DECONZ_DEVICE"
+    [-t]="30"
+)
+
+# ---------------------------
+# Firmware details
+# ---------------------------
 FW_PATH=/usr/share/deCONZ/firmware/
 FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
 
@@ -59,6 +89,21 @@ function exit_on_enter() {
     [[ -n $input ]] || exit_with_error
 }
 
+# ===========================
+# utility functions
+# ===========================
+# ---------------------------
+# Parse all options passed to the script.
+# Options of the flasher are valid options.
+# ---------------------------
+function parse_options() {
+    while (( $# > 0)); do
+        [[ -n ${FLASHER_PARAM_NAMES[$1]} ]] || exit_with_error "Unknown argument '$1'. Exiting ..."
+        FLASHER_PARAM_VALUES[$1]="$2"
+        shift 2
+    done
+}
+
 echo "-------------------------------------------------------------------"
 echo " "
 echo "             marthoc/deconz Firmware Flashing Script"
@@ -67,6 +112,9 @@ echo "                       Version: $VERSION"
 echo " "
 echo "-------------------------------------------------------------------"
 echo " "
+
+parse_options
+
 echo " "
 echo "Listing attached devices..."
 echo " "
@@ -77,8 +125,8 @@ echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
 
-read -p "Device path : " deviceName
-exit_on_enter $deviceName
+read -ep "Device path : " -i "${FLASHER_PARAM_VALUES[-d]}" FLASHER_PARAM_VALUES[-d]
+exit_on_enter ${FLASHER_PARAM_VALUES[-d]}
 
 echo " "
 echo "-------------------------------------------------------------------"
@@ -93,40 +141,48 @@ echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
-read -p "File Name : " fileName
+read -ep "File Name : " -i "${FLASHER_PARAM_VALUES[-f]##*/}" fileName
 exit_on_enter $fileName
 echo " "
-filePath="${FW_PATH%/}/$fileName"
-if [[ ! -f $filePath ]]; then
+FLASHER_PARAM_VALUES[-f]="${FW_PATH%/}/$fileName"
+if [[ ! -f ${FLASHER_PARAM_VALUES[-f]} ]]; then
     echo "File not found locally. Try to download?"
-    read -p "Enter Y to proceed, any other entry to exit: " answer
+    read -ep "Enter Y to proceed, any other entry to exit: " answer
     [[ $answer == [yY] ]] || exit_with_error
 
     echo " "
     echo "Downloading..."
     echo " "
-    curl --fail --output "$filePath" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f $filePath ]]
-    delete_and_exit_on_error "$filePath" "Download Error! Please re-run this script..."
+    curl --fail --output "${FLASHER_PARAM_VALUES[-f]}" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f ${FLASHER_PARAM_VALUES[-f]} ]]
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Download Error! Please re-run this script..."
     echo " "
     echo "Download complete! Checking md5 checksum..."
     md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
-    [[ -z $md5 ]] || delete_and_exit_on_error "$filePath" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
-    echo "${md5% *} ${filePath}" | md5sum --check
-    delete_and_exit_on_error "$filePath" "Error comparing checksums! Please re-run this script..."
+    [[ -z $md5 ]] || delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${FLASHER_PARAM_VALUES[-f]}" | md5sum --check
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Error comparing checksums! Please re-run this script..."
     echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device ......: $deviceName"
-echo "Firmware File: $fileName"
+FLASHER_PARAMS=()
+for param in "${FLASHER_PARAM_LIST[@]}"; do
+    value="${FLASHER_PARAM_VALUES[$param]}"
+    [[ -n $value ]] || continue
+    FLASHER_PARAMS+=( "$param" "$value" )
+
+    pattern="${FLASHER_PARAM_PRINT[$param]-${FLASHER_PARAM_PRINT[default]}}"
+    [[ $value =~ $pattern ]] && printf "%s: %s\n" "${FLASHER_PARAM_NAMES[$param]}" "${BASH_REMATCH}"
+done
+
 echo " "
-echo "Are the above device and firmware values correct?"
-read -p "Enter Y to proceed, any other entry to exit: " correctVal
+echo "Are the above values correct?"
+read -ep "Enter Y to proceed, any other entry to exit: " correctVal
 [[ $correctVal == [yY] ]] || exit_with_error
 
 echo " "
 echo "Flashing..."
 echo " "
-$FLASHER -d $deviceName -f "$filePath"
+$FLASHER "${FLASHER_PARAMS[@]}"
 exit_on_error "Flashing Error! Please re-run this script..."

--- a/arm64/root/firmware-update.sh
+++ b/arm64/root/firmware-update.sh
@@ -29,7 +29,7 @@ typeset -A FLASHER_PARAM_PRINT=(
 # Default values
 typeset -A FLASHER_PARAM_VALUES=(
     [-d]="$DECONZ_DEVICE"
-    [-t]="30"
+    [-t]="60"
 )
 
 # ---------------------------
@@ -113,7 +113,7 @@ echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 
-parse_options
+parse_options "$@"
 
 echo " "
 echo "Listing attached devices..."

--- a/armv7/root/firmware-update.sh
+++ b/armv7/root/firmware-update.sh
@@ -1,9 +1,63 @@
 #!/bin/bash
 
-VERSION=0.6
+# ===========================
+# Configuration
+# ===========================
+VERSION=0.7
 FLASHER=/usr/bin/GCFFlasher_internal
 FW_PATH=/usr/share/deCONZ/firmware/
-FW_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+
+# ===========================
+# exit functions
+# ===========================
+# ---------------------------
+# Exit the script
+# - on exit print 1st param or "Exiting..." as message
+# - use 2nd param or 1 as exit-code
+# ---------------------------
+function exit_with_error() {
+    typeset msg="${1:-Exiting...}"
+    typeset -i retVal="${2:-1}"
+    printf "\n%s\n\n" "$msg"
+    exit $retVal
+}
+
+# ---------------------------
+# Check last return-code or 2nd param
+# - if non-zero exit with message
+# - on exit print 1st param or "Exiting..." as message
+# ---------------------------
+function exit_on_error() {
+    typeset msg="$1"
+    typeset -i retVal="${2:-$?}"
+    (( retVal == 0 )) || exit_with_error "$msg" $retVal
+}
+
+# ---------------------------
+# Check last return-code or 3rd param
+# - if non-zero exit with message
+# - on exit remove file (1st param) if present
+# - on exit print 2nd param or "Exiting..." as message
+# ---------------------------
+function delete_and_exit_on_error() {
+    typeset file="$1"
+    typeset msg="$2"
+    typeset -i retVal="${2:-$?}"
+    if (( retVal != 0 )); then
+        [[ -f $file ]] && rm "$file"
+        exit_with_error "$msg" $retVal
+    fi
+}
+
+# ---------------------------
+# Check 1st param as user-input
+# - exit script on empty input
+# ---------------------------
+function exit_on_enter() {
+    typeset input="$1"
+    [[ -n $input ]] || exit_with_error
+}
 
 echo "-------------------------------------------------------------------"
 echo " "
@@ -22,13 +76,11 @@ $FLASHER -l
 echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
-read -p "Device Path : " deviceName
-echo " "
-if [[ -z "${deviceName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 
+read -p "Device path : " deviceName
+exit_on_enter $deviceName
+
+echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 echo "Firmware available for flashing:"
@@ -37,74 +89,44 @@ ls -1 "$FW_PATH"
 echo " "
 echo "Enter the firmware file name from above, including extension."
 echo "Alternatively, you may enter the name of a firmware file to download"
-echo "from $FW_BASE"
+echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
 read -p "File Name : " fileName
+exit_on_enter $fileName
 echo " "
-if [[ -z "${fileName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 filePath="${FW_PATH%/}/$fileName"
 if [[ ! -f $filePath ]]; then
-        echo "File not found locally. Try to download?"
-        read -p "Enter Y to proceed, any other entry to exit: " answer
-        echo " "
-        if [[ $answer != [yY] ]]; then
-                echo "Exiting..."
-                exit 1
-        fi
-        echo "Downloading..."
-        echo " "
-        curl --fail --output "$filePath" "${FW_BASE%/}/$fileName"
-        retVal=$?
-        if [[ ! -f $filePath ]] || (( retVal != 0 )); then
-                echo " "
-                echo "Download Error! Please re-run this script..."
-                echo " "
-                [[ -f $filePath ]] && rm "$filePath"
-                exit $(( retVal == 0 ? 1 : retVal ))
-        fi
-        echo " "
-        echo "Download complete! Checking md5 checksum..."
-        md5=$(curl --fail --silent "${FW_BASE%/}/${fileName}.md5")
-        echo "${md5% *} ${filePath}" | md5sum --check
-        retVal=$?
-        echo " "
-        if (( retVal != 0 )); then
-                echo "Error comparing checksums! Please re-run this script..."
-                echo " "
-                rm "$filePath"
-                exit $retVal
-        fi
+    echo "File not found locally. Try to download?"
+    read -p "Enter Y to proceed, any other entry to exit: " answer
+    [[ $answer == [yY] ]] || exit_with_error
+
+    echo " "
+    echo "Downloading..."
+    echo " "
+    curl --fail --output "$filePath" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f $filePath ]]
+    delete_and_exit_on_error "$filePath" "Download Error! Please re-run this script..."
+    echo " "
+    echo "Download complete! Checking md5 checksum..."
+    md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
+    [[ -z $md5 ]] || delete_and_exit_on_error "$filePath" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${filePath}" | md5sum --check
+    delete_and_exit_on_error "$filePath" "Error comparing checksums! Please re-run this script..."
+    echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device: $deviceName"
-echo " "
+echo "Device ......: $deviceName"
 echo "Firmware File: $fileName"
 echo " "
 echo "Are the above device and firmware values correct?"
 read -p "Enter Y to proceed, any other entry to exit: " correctVal
+[[ $correctVal == [yY] ]] || exit_with_error
+
 echo " "
-
-if [[ $correctVal == [yY] ]]; then
-        echo "Flashing..."
-        echo " "
-        $FLASHER -t 60 -d $deviceName -f "$filePath"
-
-        retVal=$?
-        if (( retVal != 0 )); then
-                echo " "
-                echo "Flashing Error! Please re-run this script..."
-                echo " "
-                exit $retVal
-        fi
-else
-        echo "Exiting..."
-        echo " "
-        exit 1
-fi
+echo "Flashing..."
+echo " "
+$FLASHER -d $deviceName -f "$filePath"
+exit_on_error "Flashing Error! Please re-run this script..."

--- a/armv7/root/firmware-update.sh
+++ b/armv7/root/firmware-update.sh
@@ -4,7 +4,37 @@
 # Configuration
 # ===========================
 VERSION=0.7
+# ---------------------------
+# Flasher and options
+# ---------------------------
 FLASHER=/usr/bin/GCFFlasher_internal
+FLASHER_PARAM_LIST=( -d -f -s -t -R -B -x )
+typeset -A FLASHER_PARAM_NAMES=( # GCFFlasher <options>
+                                 #  -r              force device reset without programming
+    [-f]="Firmware file"         #  -f <firmware>   flash firmware file
+    [-d]="Device path ."         #  -d <device>     device number or path to use, e.g. 0, /dev/ttyUSB0 or RaspBee
+    [-s]="Serial number"         #  -s <serial>     serial number to use
+    [-t]="Timeout ....."         #  -t <timeout>    retry until timeout (seconds) is reached
+    [-R]="Retries ....."         #  -R <retries>    max. retries
+    [-B]="Baudrate ...."         #  -B <baudrate>   custom baudrate
+                                 #  -l              list devices
+    [-x]="Loglevel ...."         #  -x <loglevel>   debug log level 0, 1, 3
+                                 #  -j <test>       runs a test 1
+                                 #  -h -?           print this help
+)
+typeset -A FLASHER_PARAM_PRINT=(
+    [-f]="[^/]*$"
+    [default]=".*"
+)
+# Default values
+typeset -A FLASHER_PARAM_VALUES=(
+    [-d]="$DECONZ_DEVICE"
+    [-t]="30"
+)
+
+# ---------------------------
+# Firmware details
+# ---------------------------
 FW_PATH=/usr/share/deCONZ/firmware/
 FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
 
@@ -59,6 +89,21 @@ function exit_on_enter() {
     [[ -n $input ]] || exit_with_error
 }
 
+# ===========================
+# utility functions
+# ===========================
+# ---------------------------
+# Parse all options passed to the script.
+# Options of the flasher are valid options.
+# ---------------------------
+function parse_options() {
+    while (( $# > 0)); do
+        [[ -n ${FLASHER_PARAM_NAMES[$1]} ]] || exit_with_error "Unknown argument '$1'. Exiting ..."
+        FLASHER_PARAM_VALUES[$1]="$2"
+        shift 2
+    done
+}
+
 echo "-------------------------------------------------------------------"
 echo " "
 echo "             marthoc/deconz Firmware Flashing Script"
@@ -67,6 +112,9 @@ echo "                       Version: $VERSION"
 echo " "
 echo "-------------------------------------------------------------------"
 echo " "
+
+parse_options
+
 echo " "
 echo "Listing attached devices..."
 echo " "
@@ -77,8 +125,8 @@ echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
 
-read -p "Device path : " deviceName
-exit_on_enter $deviceName
+read -ep "Device path : " -i "${FLASHER_PARAM_VALUES[-d]}" FLASHER_PARAM_VALUES[-d]
+exit_on_enter ${FLASHER_PARAM_VALUES[-d]}
 
 echo " "
 echo "-------------------------------------------------------------------"
@@ -93,40 +141,48 @@ echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
-read -p "File Name : " fileName
+read -ep "File Name : " -i "${FLASHER_PARAM_VALUES[-f]##*/}" fileName
 exit_on_enter $fileName
 echo " "
-filePath="${FW_PATH%/}/$fileName"
-if [[ ! -f $filePath ]]; then
+FLASHER_PARAM_VALUES[-f]="${FW_PATH%/}/$fileName"
+if [[ ! -f ${FLASHER_PARAM_VALUES[-f]} ]]; then
     echo "File not found locally. Try to download?"
-    read -p "Enter Y to proceed, any other entry to exit: " answer
+    read -ep "Enter Y to proceed, any other entry to exit: " answer
     [[ $answer == [yY] ]] || exit_with_error
 
     echo " "
     echo "Downloading..."
     echo " "
-    curl --fail --output "$filePath" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f $filePath ]]
-    delete_and_exit_on_error "$filePath" "Download Error! Please re-run this script..."
+    curl --fail --output "${FLASHER_PARAM_VALUES[-f]}" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f ${FLASHER_PARAM_VALUES[-f]} ]]
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Download Error! Please re-run this script..."
     echo " "
     echo "Download complete! Checking md5 checksum..."
     md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
-    [[ -z $md5 ]] || delete_and_exit_on_error "$filePath" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
-    echo "${md5% *} ${filePath}" | md5sum --check
-    delete_and_exit_on_error "$filePath" "Error comparing checksums! Please re-run this script..."
+    [[ -z $md5 ]] || delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${FLASHER_PARAM_VALUES[-f]}" | md5sum --check
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Error comparing checksums! Please re-run this script..."
     echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device ......: $deviceName"
-echo "Firmware File: $fileName"
+FLASHER_PARAMS=()
+for param in "${FLASHER_PARAM_LIST[@]}"; do
+    value="${FLASHER_PARAM_VALUES[$param]}"
+    [[ -n $value ]] || continue
+    FLASHER_PARAMS+=( "$param" "$value" )
+
+    pattern="${FLASHER_PARAM_PRINT[$param]-${FLASHER_PARAM_PRINT[default]}}"
+    [[ $value =~ $pattern ]] && printf "%s: %s\n" "${FLASHER_PARAM_NAMES[$param]}" "${BASH_REMATCH}"
+done
+
 echo " "
-echo "Are the above device and firmware values correct?"
-read -p "Enter Y to proceed, any other entry to exit: " correctVal
+echo "Are the above values correct?"
+read -ep "Enter Y to proceed, any other entry to exit: " correctVal
 [[ $correctVal == [yY] ]] || exit_with_error
 
 echo " "
 echo "Flashing..."
 echo " "
-$FLASHER -d $deviceName -f "$filePath"
+$FLASHER "${FLASHER_PARAMS[@]}"
 exit_on_error "Flashing Error! Please re-run this script..."

--- a/armv7/root/firmware-update.sh
+++ b/armv7/root/firmware-update.sh
@@ -29,7 +29,7 @@ typeset -A FLASHER_PARAM_PRINT=(
 # Default values
 typeset -A FLASHER_PARAM_VALUES=(
     [-d]="$DECONZ_DEVICE"
-    [-t]="30"
+    [-t]="60"
 )
 
 # ---------------------------
@@ -113,7 +113,7 @@ echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 
-parse_options
+parse_options "$@"
 
 echo " "
 echo "Listing attached devices..."


### PR DESCRIPTION
@phdelodder. Here you find the changes mentioned in #318. Thanks for testing.
I assumed the PR would be more slim as I just cherry-picked my 4 commits ...

----
On invocation of the update-script you could additionally add options:

```bash
docker run -it --rm --entrypoint "/firmware-update.sh" --privileged --cap-add=ALL -v /dev:/dev -v /lib/modules:/lib/modules -v /sys:/sys marthoc/deconz <option1> <value1> <option2> <value2> ...
```

These options will be read by the script and checked against the possible options of the `GCFFlasher_internal`. Using this mechanism one could specify values for `device-name`, `timeout`, `retries` or the `loglevel`.
Additionally the script defines a default of 60 seconds for the timeout-parameter.