### PR TITLE
Add support for version-specific multiarch tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,17 @@ after_success:
       docker push marthoc/deconz:arm64-$BUILD_VERSION
       docker push marthoc/deconz:aarch64
       docker push marthoc/deconz:aarch64-$BUILD_VERSION
+# Update "latest" multiarch tag
       ./manifest-tool --username $DOCKER_LOGIN --password $DOCKER_PASS push from-args \
         --platforms linux/amd64,linux/arm/v7,linux/arm64 \
         --template marthoc/deconz:ARCHVARIANT-$BUILD_VERSION \
-        --target marthoc/deconz:latest 
+        --target marthoc/deconz:latest
+# Update version multiarch tag
+      ./manifest-tool --username $DOCKER_LOGIN --password $DOCKER_PASS push from-args \
+        --platforms linux/amd64,linux/arm/v7,linux/arm64 \
+        --template marthoc/deconz:ARCHVARIANT-$BUILD_VERSION \
+        --target marthoc/deconz:$BUILD_VERSION
+# Update "stable" multiarch tag if a stable release
       if [ "$BUILD_CHANNEL" == "stable" ]; then
         ./manifest-tool --username $DOCKER_LOGIN --password $DOCKER_PASS push from-args \
           --platforms linux/amd64,linux/arm/v7,linux/arm64 \

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Builds of this image are available on (and should be pulled from) Docker Hub, wi
 |---|-----------|
 |marthoc/deconz:latest|Latest release of deCONZ, stable or beta|
 |marthoc/deconz:stable|Stable releases of deCONZ only|
-|marthoc/deconz:arch-version|Specific releases of deCONZ, use only if you wish to pin your version of deCONZ|
+|marthoc/deconz:version|Specific versions of deCONZ, use only if you wish to pin your version of deCONZ|
 |marthoc/deconz:arch-test|Test builds of this image, not for use by end users, only for developer testing!|
+
+The "latest", "stable", and "version" tags have multiarch support for amd64, armv7, and arm64, so specifying any of these tags will pull the correct version for your architecture.
 
 Please consult Docker Hub for the latest available versions of this image.
 


### PR DESCRIPTION
This PR adds support for a new version-specific multiarch tag for the image - e.g. marthoc/deconz:2.10.04 - so that specifying a version as the tag number will pull the correct version for the hardware architecture.