### PR TITLE
Options for GCFFlasher

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ If you have multiple usb devices, you can map the `/dev/...` volume correspondin
 docker run -it --rm --entrypoint "/firmware-update.sh" --privileged --cap-add=ALL -v /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DExxxxxxx-if00:/dev/ttyACM0  -v /lib/modules:/lib/modules -v /sys:/sys marthoc/deconz
 ```
 
+You could also put additional options to the end of this call:
+```bash
+docker run ... marthoc/deconz <option1> <value1> <option2> <value2> ...
+```
+If these are valid options for the flashing tool they will be added to the call:
+- `-f <firmware>`   flash firmware file
+- `-d <device>`     device number or path to use, e.g. 0, /dev/ttyUSB0 or RaspBee
+- `-t <timeout>`    retry until timeout (seconds) is reached
+- `-R <retries>`    max. retries
+- `-x <loglevel>`   debug log level 0, 1, 3
+
+Please note that the values for device and firmware-file are still asked by the script but your options are taken as default.
+The timeout defaults to 60 seconds.
+
 4. Follow the prompts:
 - Enter the path (e.g. `/dev/ttyUSB0`) that corresponds to your device in the listing.
 - Type or paste the full file name that corresponds to the file name that you found in the deCONZ container logs in step 1 (or, select a different filename, but you should have a good reason for doing this).
@@ -178,6 +192,10 @@ docker run -it --rm --entrypoint "/firmware-update.sh" --privileged --cap-add=AL
 Q: Why does the script give an error about not being able to unload modules ftdi_sio and usbserial, or that the device couldn't be rest?
 
 A: In order to flash the device, no other program or device on the system can be using these kernel modules or the device. Stop any program/container that could be using the modules or device (likely deCONZ) and then invoke the script again. If the error persists, you may need to temporarily remove other USB serial devices from the system in order allow the script to completely unload the kernel modules.
+
+Q: Why does a flush run fail after some seconds even if I specified a timeout much longer?
+
+A: By setting a timeout you allowed the flashing tool to start as many runs as will fit into this period. The timeout of a single run can not be changed by parameters.
 
 ### Viewing the deCONZ ZigBee mesh with VNC
 

--- a/amd64/root/firmware-update.sh
+++ b/amd64/root/firmware-update.sh
@@ -1,9 +1,63 @@
 #!/bin/bash
 
-VERSION=0.6
+# ===========================
+# Configuration
+# ===========================
+VERSION=0.7
 FLASHER=/usr/bin/GCFFlasher_internal
 FW_PATH=/usr/share/deCONZ/firmware/
-FW_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+
+# ===========================
+# exit functions
+# ===========================
+# ---------------------------
+# Exit the script
+# - on exit print 1st param or "Exiting..." as message
+# - use 2nd param or 1 as exit-code
+# ---------------------------
+function exit_with_error() {
+    typeset msg="${1:-Exiting...}"
+    typeset -i retVal="${2:-1}"
+    printf "\n%s\n\n" "$msg"
+    exit $retVal
+}
+
+# ---------------------------
+# Check last return-code or 2nd param
+# - if non-zero exit with message
+# - on exit print 1st param or "Exiting..." as message
+# ---------------------------
+function exit_on_error() {
+    typeset -i retVal="${2:-$?}"
+    typeset msg="$1"
+    (( retVal == 0 )) || exit_with_error "$msg" $retVal
+}
+
+# ---------------------------
+# Check last return-code or 3rd param
+# - if non-zero exit with message
+# - on exit remove file (1st param) if present
+# - on exit print 2nd param or "Exiting..." as message
+# ---------------------------
+function delete_and_exit_on_error() {
+    typeset -i retVal="${3:-$?}"
+    typeset file="$1"
+    typeset msg="$2"
+    if (( retVal != 0 )); then
+        [[ -f $file ]] && rm "$file"
+        exit_with_error "$msg" $retVal
+    fi
+}
+
+# ---------------------------
+# Check 1st param as user-input
+# - exit script on empty input
+# ---------------------------
+function exit_on_enter() {
+    typeset input="$1"
+    [[ -n $input ]] || exit_with_error
+}
 
 echo "-------------------------------------------------------------------"
 echo " "
@@ -22,13 +76,11 @@ $FLASHER -l
 echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
-read -p "Device Path : " deviceName
-echo " "
-if [[ -z "${deviceName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 
+read -p "Device path : " deviceName
+exit_on_enter $deviceName
+
+echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 echo "Firmware available for flashing:"
@@ -37,74 +89,45 @@ ls -1 "$FW_PATH"
 echo " "
 echo "Enter the firmware file name from above, including extension."
 echo "Alternatively, you may enter the name of a firmware file to download"
-echo "from $FW_BASE"
+echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
 read -p "File Name : " fileName
+exit_on_enter $fileName
+
 echo " "
-if [[ -z "${fileName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 filePath="${FW_PATH%/}/$fileName"
 if [[ ! -f $filePath ]]; then
-        echo "File not found locally. Try to download?"
-        read -p "Enter Y to proceed, any other entry to exit: " answer
-        echo " "
-        if [[ $answer != [yY] ]]; then
-                echo "Exiting..."
-                exit 1
-        fi
-        echo "Downloading..."
-        echo " "
-        curl --fail --output "$filePath" "${FW_BASE%/}/$fileName"
-        retVal=$?
-        if [[ ! -f $filePath ]] || (( retVal != 0 )); then
-                echo " "
-                echo "Download Error! Please re-run this script..."
-                echo " "
-                [[ -f $filePath ]] && rm "$filePath"
-                exit $(( retVal == 0 ? 1 : retVal ))
-        fi
-        echo " "
-        echo "Download complete! Checking md5 checksum..."
-        md5=$(curl --fail --silent "${FW_BASE%/}/${fileName}.md5")
-        echo "${md5% *} ${filePath}" | md5sum --check
-        retVal=$?
-        echo " "
-        if (( retVal != 0 )); then
-                echo "Error comparing checksums! Please re-run this script..."
-                echo " "
-                rm "$filePath"
-                exit $retVal
-        fi
+    echo "File not found locally. Try to download?"
+    read -p "Enter Y to proceed, any other entry to exit: " answer
+    [[ $answer == [yY] ]] || exit_with_error
+
+    echo " "
+    echo "Downloading..."
+    echo " "
+    curl --fail --output "$filePath" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f $filePath ]]
+    delete_and_exit_on_error "$filePath" "Download Error! Please re-run this script..."
+    echo " "
+    echo "Download complete! Checking md5 checksum..."
+    md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
+    [[ -n $md5 ]] || delete_and_exit_on_error "$filePath" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${filePath}" | md5sum --check
+    delete_and_exit_on_error "$filePath" "Error comparing checksums! Please re-run this script..."
+    echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device: $deviceName"
-echo " "
+echo "Device ......: $deviceName"
 echo "Firmware File: $fileName"
 echo " "
 echo "Are the above device and firmware values correct?"
 read -p "Enter Y to proceed, any other entry to exit: " correctVal
+[[ $correctVal == [yY] ]] || exit_with_error
+
 echo " "
-
-if [[ $correctVal == [yY] ]]; then
-        echo "Flashing..."
-        echo " "
-        $FLASHER -t 60 -d $deviceName -f "$filePath"
-
-        retVal=$?
-        if (( retVal != 0 )); then
-                echo " "
-                echo "Flashing Error! Please re-run this script..."
-                echo " "
-                exit $retVal
-        fi
-else
-        echo "Exiting..."
-        echo " "
-        exit 1
-fi
+echo "Flashing..."
+echo " "
+$FLASHER -t 60 -d $deviceName -f "$filePath"
+exit_on_error "Flashing Error! Please re-run this script..."

--- a/arm64/root/firmware-update.sh
+++ b/arm64/root/firmware-update.sh
@@ -1,9 +1,63 @@
 #!/bin/bash
 
-VERSION=0.6
+# ===========================
+# Configuration
+# ===========================
+VERSION=0.7
 FLASHER=/usr/bin/GCFFlasher_internal
 FW_PATH=/usr/share/deCONZ/firmware/
-FW_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+
+# ===========================
+# exit functions
+# ===========================
+# ---------------------------
+# Exit the script
+# - on exit print 1st param or "Exiting..." as message
+# - use 2nd param or 1 as exit-code
+# ---------------------------
+function exit_with_error() {
+    typeset msg="${1:-Exiting...}"
+    typeset -i retVal="${2:-1}"
+    printf "\n%s\n\n" "$msg"
+    exit $retVal
+}
+
+# ---------------------------
+# Check last return-code or 2nd param
+# - if non-zero exit with message
+# - on exit print 1st param or "Exiting..." as message
+# ---------------------------
+function exit_on_error() {
+    typeset -i retVal="${2:-$?}"
+    typeset msg="$1"
+    (( retVal == 0 )) || exit_with_error "$msg" $retVal
+}
+
+# ---------------------------
+# Check last return-code or 3rd param
+# - if non-zero exit with message
+# - on exit remove file (1st param) if present
+# - on exit print 2nd param or "Exiting..." as message
+# ---------------------------
+function delete_and_exit_on_error() {
+    typeset -i retVal="${3:-$?}"
+    typeset file="$1"
+    typeset msg="$2"
+    if (( retVal != 0 )); then
+        [[ -f $file ]] && rm "$file"
+        exit_with_error "$msg" $retVal
+    fi
+}
+
+# ---------------------------
+# Check 1st param as user-input
+# - exit script on empty input
+# ---------------------------
+function exit_on_enter() {
+    typeset input="$1"
+    [[ -n $input ]] || exit_with_error
+}
 
 echo "-------------------------------------------------------------------"
 echo " "
@@ -22,13 +76,11 @@ $FLASHER -l
 echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
-read -p "Device Path : " deviceName
-echo " "
-if [[ -z "${deviceName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 
+read -p "Device path : " deviceName
+exit_on_enter $deviceName
+
+echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 echo "Firmware available for flashing:"
@@ -37,74 +89,45 @@ ls -1 "$FW_PATH"
 echo " "
 echo "Enter the firmware file name from above, including extension."
 echo "Alternatively, you may enter the name of a firmware file to download"
-echo "from $FW_BASE"
+echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
 read -p "File Name : " fileName
+exit_on_enter $fileName
+
 echo " "
-if [[ -z "${fileName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 filePath="${FW_PATH%/}/$fileName"
 if [[ ! -f $filePath ]]; then
-        echo "File not found locally. Try to download?"
-        read -p "Enter Y to proceed, any other entry to exit: " answer
-        echo " "
-        if [[ $answer != [yY] ]]; then
-                echo "Exiting..."
-                exit 1
-        fi
-        echo "Downloading..."
-        echo " "
-        curl --fail --output "$filePath" "${FW_BASE%/}/$fileName"
-        retVal=$?
-        if [[ ! -f $filePath ]] || (( retVal != 0 )); then
-                echo " "
-                echo "Download Error! Please re-run this script..."
-                echo " "
-                [[ -f $filePath ]] && rm "$filePath"
-                exit $(( retVal == 0 ? 1 : retVal ))
-        fi
-        echo " "
-        echo "Download complete! Checking md5 checksum..."
-        md5=$(curl --fail --silent "${FW_BASE%/}/${fileName}.md5")
-        echo "${md5% *} ${filePath}" | md5sum --check
-        retVal=$?
-        echo " "
-        if (( retVal != 0 )); then
-                echo "Error comparing checksums! Please re-run this script..."
-                echo " "
-                rm "$filePath"
-                exit $retVal
-        fi
+    echo "File not found locally. Try to download?"
+    read -p "Enter Y to proceed, any other entry to exit: " answer
+    [[ $answer == [yY] ]] || exit_with_error
+
+    echo " "
+    echo "Downloading..."
+    echo " "
+    curl --fail --output "$filePath" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f $filePath ]]
+    delete_and_exit_on_error "$filePath" "Download Error! Please re-run this script..."
+    echo " "
+    echo "Download complete! Checking md5 checksum..."
+    md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
+    [[ -n $md5 ]] || delete_and_exit_on_error "$filePath" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${filePath}" | md5sum --check
+    delete_and_exit_on_error "$filePath" "Error comparing checksums! Please re-run this script..."
+    echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device: $deviceName"
-echo " "
+echo "Device ......: $deviceName"
 echo "Firmware File: $fileName"
 echo " "
 echo "Are the above device and firmware values correct?"
 read -p "Enter Y to proceed, any other entry to exit: " correctVal
+[[ $correctVal == [yY] ]] || exit_with_error
+
 echo " "
-
-if [[ $correctVal == [yY] ]]; then
-        echo "Flashing..."
-        echo " "
-        $FLASHER -t 60 -d $deviceName -f "$filePath"
-
-        retVal=$?
-        if (( retVal != 0 )); then
-                echo " "
-                echo "Flashing Error! Please re-run this script..."
-                echo " "
-                exit $retVal
-        fi
-else
-        echo "Exiting..."
-        echo " "
-        exit 1
-fi
+echo "Flashing..."
+echo " "
+$FLASHER -t 60 -d $deviceName -f "$filePath"
+exit_on_error "Flashing Error! Please re-run this script..."

--- a/armv7/root/firmware-update.sh
+++ b/armv7/root/firmware-update.sh
@@ -1,9 +1,63 @@
 #!/bin/bash
 
-VERSION=0.6
+# ===========================
+# Configuration
+# ===========================
+VERSION=0.7
 FLASHER=/usr/bin/GCFFlasher_internal
 FW_PATH=/usr/share/deCONZ/firmware/
-FW_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+
+# ===========================
+# exit functions
+# ===========================
+# ---------------------------
+# Exit the script
+# - on exit print 1st param or "Exiting..." as message
+# - use 2nd param or 1 as exit-code
+# ---------------------------
+function exit_with_error() {
+    typeset msg="${1:-Exiting...}"
+    typeset -i retVal="${2:-1}"
+    printf "\n%s\n\n" "$msg"
+    exit $retVal
+}
+
+# ---------------------------
+# Check last return-code or 2nd param
+# - if non-zero exit with message
+# - on exit print 1st param or "Exiting..." as message
+# ---------------------------
+function exit_on_error() {
+    typeset -i retVal="${2:-$?}"
+    typeset msg="$1"
+    (( retVal == 0 )) || exit_with_error "$msg" $retVal
+}
+
+# ---------------------------
+# Check last return-code or 3rd param
+# - if non-zero exit with message
+# - on exit remove file (1st param) if present
+# - on exit print 2nd param or "Exiting..." as message
+# ---------------------------
+function delete_and_exit_on_error() {
+    typeset -i retVal="${3:-$?}"
+    typeset file="$1"
+    typeset msg="$2"
+    if (( retVal != 0 )); then
+        [[ -f $file ]] && rm "$file"
+        exit_with_error "$msg" $retVal
+    fi
+}
+
+# ---------------------------
+# Check 1st param as user-input
+# - exit script on empty input
+# ---------------------------
+function exit_on_enter() {
+    typeset input="$1"
+    [[ -n $input ]] || exit_with_error
+}
 
 echo "-------------------------------------------------------------------"
 echo " "
@@ -22,13 +76,11 @@ $FLASHER -l
 echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
-read -p "Device Path : " deviceName
-echo " "
-if [[ -z "${deviceName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 
+read -p "Device path : " deviceName
+exit_on_enter $deviceName
+
+echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 echo "Firmware available for flashing:"
@@ -37,74 +89,45 @@ ls -1 "$FW_PATH"
 echo " "
 echo "Enter the firmware file name from above, including extension."
 echo "Alternatively, you may enter the name of a firmware file to download"
-echo "from $FW_BASE"
+echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
 read -p "File Name : " fileName
+exit_on_enter $fileName
+
 echo " "
-if [[ -z "${fileName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 filePath="${FW_PATH%/}/$fileName"
 if [[ ! -f $filePath ]]; then
-        echo "File not found locally. Try to download?"
-        read -p "Enter Y to proceed, any other entry to exit: " answer
-        echo " "
-        if [[ $answer != [yY] ]]; then
-                echo "Exiting..."
-                exit 1
-        fi
-        echo "Downloading..."
-        echo " "
-        curl --fail --output "$filePath" "${FW_BASE%/}/$fileName"
-        retVal=$?
-        if [[ ! -f $filePath ]] || (( retVal != 0 )); then
-                echo " "
-                echo "Download Error! Please re-run this script..."
-                echo " "
-                [[ -f $filePath ]] && rm "$filePath"
-                exit $(( retVal == 0 ? 1 : retVal ))
-        fi
-        echo " "
-        echo "Download complete! Checking md5 checksum..."
-        md5=$(curl --fail --silent "${FW_BASE%/}/${fileName}.md5")
-        echo "${md5% *} ${filePath}" | md5sum --check
-        retVal=$?
-        echo " "
-        if (( retVal != 0 )); then
-                echo "Error comparing checksums! Please re-run this script..."
-                echo " "
-                rm "$filePath"
-                exit $retVal
-        fi
+    echo "File not found locally. Try to download?"
+    read -p "Enter Y to proceed, any other entry to exit: " answer
+    [[ $answer == [yY] ]] || exit_with_error
+
+    echo " "
+    echo "Downloading..."
+    echo " "
+    curl --fail --output "$filePath" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f $filePath ]]
+    delete_and_exit_on_error "$filePath" "Download Error! Please re-run this script..."
+    echo " "
+    echo "Download complete! Checking md5 checksum..."
+    md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
+    [[ -n $md5 ]] || delete_and_exit_on_error "$filePath" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${filePath}" | md5sum --check
+    delete_and_exit_on_error "$filePath" "Error comparing checksums! Please re-run this script..."
+    echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device: $deviceName"
-echo " "
+echo "Device ......: $deviceName"
 echo "Firmware File: $fileName"
 echo " "
 echo "Are the above device and firmware values correct?"
 read -p "Enter Y to proceed, any other entry to exit: " correctVal
+[[ $correctVal == [yY] ]] || exit_with_error
+
 echo " "
-
-if [[ $correctVal == [yY] ]]; then
-        echo "Flashing..."
-        echo " "
-        $FLASHER -t 60 -d $deviceName -f "$filePath"
-
-        retVal=$?
-        if (( retVal != 0 )); then
-                echo " "
-                echo "Flashing Error! Please re-run this script..."
-                echo " "
-                exit $retVal
-        fi
-else
-        echo "Exiting..."
-        echo " "
-        exit 1
-fi
+echo "Flashing..."
+echo " "
+$FLASHER -t 60 -d $deviceName -f "$filePath"
+exit_on_error "Flashing Error! Please re-run this script..."


### PR DESCRIPTION
Ok - next try with only two commits. This PR replaces #374.

----
On invocation of the update-script you could additionally add options:

```bash
docker run -it --rm --entrypoint "/firmware-update.sh" --privileged --cap-add=ALL -v /dev:/dev -v /lib/modules:/lib/modules -v /sys:/sys marthoc/deconz <option1> <value1> <option2> <value2> ...
```

These options will be read by the script and checked against the possible options of the `GCFFlasher_internal`. Using this mechanism one could specify values for `device-name`, `timeout`, `retries` or the `loglevel`.
Additionally the script defines a default of 60 seconds for the timeout-parameter.