### PR TITLE
April 2021 Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,17 @@ after_success:
       docker push marthoc/deconz:arm64-$BUILD_VERSION
       docker push marthoc/deconz:aarch64
       docker push marthoc/deconz:aarch64-$BUILD_VERSION
+# Update "latest" multiarch tag
       ./manifest-tool --username $DOCKER_LOGIN --password $DOCKER_PASS push from-args \
         --platforms linux/amd64,linux/arm/v7,linux/arm64 \
         --template marthoc/deconz:ARCHVARIANT-$BUILD_VERSION \
-        --target marthoc/deconz:latest 
+        --target marthoc/deconz:latest
+# Update version multiarch tag
+      ./manifest-tool --username $DOCKER_LOGIN --password $DOCKER_PASS push from-args \
+        --platforms linux/amd64,linux/arm/v7,linux/arm64 \
+        --template marthoc/deconz:ARCHVARIANT-$BUILD_VERSION \
+        --target marthoc/deconz:$BUILD_VERSION
+# Update "stable" multiarch tag if a stable release
       if [ "$BUILD_CHANNEL" == "stable" ]; then
         ./manifest-tool --username $DOCKER_LOGIN --password $DOCKER_PASS push from-args \
           --platforms linux/amd64,linux/arm/v7,linux/arm64 \

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Builds of this image are available on (and should be pulled from) Docker Hub, wi
 |---|-----------|
 |marthoc/deconz:latest|Latest release of deCONZ, stable or beta|
 |marthoc/deconz:stable|Stable releases of deCONZ only|
-|marthoc/deconz:arch-version|Specific releases of deCONZ, use only if you wish to pin your version of deCONZ|
+|marthoc/deconz:version|Specific versions of deCONZ, use only if you wish to pin your version of deCONZ|
 |marthoc/deconz:arch-test|Test builds of this image, not for use by end users, only for developer testing!|
+
+The "latest", "stable", and "version" tags have multiarch support for amd64, armv7, and arm64, so specifying any of these tags will pull the correct version for your architecture.
 
 Please consult Docker Hub for the latest available versions of this image.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Use these environment variables to change the default behaviour of the container
 |`-e DECONZ_VNC_MODE=1`|Set this option to enable VNC access to the container to view the deCONZ ZigBee mesh|
 |`-e DECONZ_VNC_PORT=5900`|Default port for VNC mode is 5900; this option can be used to change this port|
 |`-e DECONZ_VNC_PASSWORD=changeme`|Default password for VNC mode is 'changeme'; this option can (should) be used to change the default password|
+|`-e DECONZ_VNC_PASSWORD_FILE=/var/secrets/my_secret`|Per default this is disabled and DECONZ_VNC_PASSWORD is used. Details on creating secrets for use with Docker containers can be found in the [corresponding section from the official documentation](https://docs.docker.com/engine/swarm/secrets/) |
+|`-e DECONZ_NOVNC_PORT=6080`|Default port for noVNC is 6080; this option can be used to change this port; setting the port to `0` will disable the noVNC functionality|
 |`-e DECONZ_UPNP=0`|Set this option to 0 to disable uPNP, see: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/274|
 
 #### Docker-Compose
@@ -238,6 +240,13 @@ tigervncserver: /usr/bin/Xtigervnc did not start up, please look into '/root/.vn
 Invalid MIT-MAGIC-COOKIE-1 keyqt.qpa.screen: QXcbConnection: Could not connect to display :0
 Could not connect to any X display.
 ```
+
+By enabling VNC, per default, you also enabled noVNC which allows you to connect using a browser. Per default the port is been set to 6080 and if you are not using "--host" networking you need to open the port using the -p directive.
+Access is through https://hostname:6080/vnc.html, this is a self signed SSL certificate so you need to accept it before you can access the page. If you do not want to enable noVNC, you can disable it using the environment variable `DECONZ_NOVNC_PORT=0`
+
+NoVNC acts as a proxy for the VNC server, meaning that if you disable VNC functionality, noVNC will not be available either.
+
+The minimum port for DECONZ_VNC_PORT must be 5900 or higher and the minimum port for DECONZ_NOVNC_PORT must be 6080 or higher. 
 
 ### Gotchas / Known Issues
 

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.6-slim
+FROM ubuntu:20.04
 
 # Build arguments
 ARG VERSION
@@ -18,7 +18,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DECONZ_VNC_MODE=0 \
     DECONZ_VNC_DISPLAY=0 \
     DECONZ_VNC_PASSWORD=changeme \
+    DECONZ_VNC_PASSWORD_FILE=0 \
     DECONZ_VNC_PORT=5900 \
+    DECONZ_NOVNC_PORT=6080 \
     DECONZ_UPNP=1
 
 # Install deCONZ dependencies
@@ -38,7 +40,9 @@ RUN apt-get update && \
         sqlite3 \
         tigervnc-standalone-server \
         tigervnc-common \
-        wmii \
+        novnc \
+        websockify \
+        openbox \
         xfonts-base \
         xfonts-scalable && \
     apt-get clean && \
@@ -66,6 +70,6 @@ RUN dpkg -i /deconz.deb && \
 
 VOLUME [ "/root/.local/share/dresden-elektronik/deCONZ" ]
 
-EXPOSE ${DECONZ_WEB_PORT} ${DECONZ_WS_PORT} ${DECONZ_VNC_PORT}
+EXPOSE ${DECONZ_WEB_PORT} ${DECONZ_WS_PORT} ${DECONZ_VNC_PORT} ${DECONZ_NOVNC_PORT}
 
 ENTRYPOINT [ "/start.sh" ]

--- a/amd64/root/firmware-update.sh
+++ b/amd64/root/firmware-update.sh
@@ -1,9 +1,108 @@
 #!/bin/bash
 
-VERSION=0.6
+# ===========================
+# Configuration
+# ===========================
+VERSION=0.7
+# ---------------------------
+# Flasher and options
+# ---------------------------
 FLASHER=/usr/bin/GCFFlasher_internal
+FLASHER_PARAM_LIST=( -d -f -s -t -R -B -x )
+typeset -A FLASHER_PARAM_NAMES=( # GCFFlasher <options>
+                                 #  -r              force device reset without programming
+    [-f]="Firmware file"         #  -f <firmware>   flash firmware file
+    [-d]="Device path ."         #  -d <device>     device number or path to use, e.g. 0, /dev/ttyUSB0 or RaspBee
+    [-s]="Serial number"         #  -s <serial>     serial number to use
+    [-t]="Timeout ....."         #  -t <timeout>    retry until timeout (seconds) is reached
+    [-R]="Retries ....."         #  -R <retries>    max. retries
+    [-B]="Baudrate ...."         #  -B <baudrate>   custom baudrate
+                                 #  -l              list devices
+    [-x]="Loglevel ...."         #  -x <loglevel>   debug log level 0, 1, 3
+                                 #  -j <test>       runs a test 1
+                                 #  -h -?           print this help
+)
+typeset -A FLASHER_PARAM_PRINT=(
+    [-f]="[^/]*$"
+    [default]=".*"
+)
+# Default values
+typeset -A FLASHER_PARAM_VALUES=(
+    [-d]="$DECONZ_DEVICE"
+    [-t]="60"
+)
+
+# ---------------------------
+# Firmware details
+# ---------------------------
 FW_PATH=/usr/share/deCONZ/firmware/
-FW_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+
+# ===========================
+# exit functions
+# ===========================
+# ---------------------------
+# Exit the script
+# - on exit print 1st param or "Exiting..." as message
+# - use 2nd param or 1 as exit-code
+# ---------------------------
+function exit_with_error() {
+    typeset msg="${1:-Exiting...}"
+    typeset -i retVal="${2:-1}"
+    printf "\n%s\n\n" "$msg"
+    exit $retVal
+}
+
+# ---------------------------
+# Check last return-code or 2nd param
+# - if non-zero exit with message
+# - on exit print 1st param or "Exiting..." as message
+# ---------------------------
+function exit_on_error() {
+    typeset -i retVal="${2:-$?}"
+    typeset msg="$1"
+    (( retVal == 0 )) || exit_with_error "$msg" $retVal
+}
+
+# ---------------------------
+# Check last return-code or 3rd param
+# - if non-zero exit with message
+# - on exit remove file (1st param) if present
+# - on exit print 2nd param or "Exiting..." as message
+# ---------------------------
+function delete_and_exit_on_error() {
+    typeset -i retVal="${3:-$?}"
+    typeset file="$1"
+    typeset msg="$2"
+    if (( retVal != 0 )); then
+        [[ -f $file ]] && rm "$file"
+        exit_with_error "$msg" $retVal
+    fi
+}
+
+# ---------------------------
+# Check 1st param as user-input
+# - exit script on empty input
+# ---------------------------
+function exit_on_enter() {
+    typeset input="$1"
+    [[ -n $input ]] || exit_with_error
+}
+
+# ===========================
+# utility functions
+# ===========================
+# ---------------------------
+# Parse all options passed to the script.
+# Options of the flasher are valid options.
+# ---------------------------
+function parse_options() {
+    while (( $# > 0)); do
+        [[ -n ${FLASHER_PARAM_NAMES[$1]} ]] || exit_with_error "Unknown argument '$1'. Exiting ..."
+        FLASHER_PARAM_VALUES[$1]="$2"
+        shift 2
+    done
+}
 
 echo "-------------------------------------------------------------------"
 echo " "
@@ -13,6 +112,9 @@ echo "                       Version: $VERSION"
 echo " "
 echo "-------------------------------------------------------------------"
 echo " "
+
+parse_options "$@"
+
 echo " "
 echo "Listing attached devices..."
 echo " "
@@ -22,13 +124,12 @@ $FLASHER -l
 echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
-read -p "Device Path : " deviceName
-echo " "
-if [[ -z "${deviceName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 
+param=-d
+read -ep "${FLASHER_PARAM_NAMES[$param]}: " -i "${FLASHER_PARAM_VALUES[$param]}" FLASHER_PARAM_VALUES[$param]
+exit_on_enter ${FLASHER_PARAM_VALUES[$param]}
+
+echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 echo "Firmware available for flashing:"
@@ -37,74 +138,54 @@ ls -1 "$FW_PATH"
 echo " "
 echo "Enter the firmware file name from above, including extension."
 echo "Alternatively, you may enter the name of a firmware file to download"
-echo "from $FW_BASE"
+echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
-read -p "File Name : " fileName
+param=-f
+read -ep "${FLASHER_PARAM_NAMES[$param]}: " -i "${FLASHER_PARAM_VALUES[$param]##*/}" fileName
+exit_on_enter $fileName
+FLASHER_PARAM_VALUES[$param]="${FW_PATH%/}/$fileName"
+
 echo " "
-if [[ -z "${fileName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
-filePath="${FW_PATH%/}/$fileName"
-if [[ ! -f $filePath ]]; then
-        echo "File not found locally. Try to download?"
-        read -p "Enter Y to proceed, any other entry to exit: " answer
-        echo " "
-        if [[ $answer != [yY] ]]; then
-                echo "Exiting..."
-                exit 1
-        fi
-        echo "Downloading..."
-        echo " "
-        curl --fail --output "$filePath" "${FW_BASE%/}/$fileName"
-        retVal=$?
-        if [[ ! -f $filePath ]] || (( retVal != 0 )); then
-                echo " "
-                echo "Download Error! Please re-run this script..."
-                echo " "
-                [[ -f $filePath ]] && rm "$filePath"
-                exit $(( retVal == 0 ? 1 : retVal ))
-        fi
-        echo " "
-        echo "Download complete! Checking md5 checksum..."
-        md5=$(curl --fail --silent "${FW_BASE%/}/${fileName}.md5")
-        echo "${md5% *} ${filePath}" | md5sum --check
-        retVal=$?
-        echo " "
-        if (( retVal != 0 )); then
-                echo "Error comparing checksums! Please re-run this script..."
-                echo " "
-                rm "$filePath"
-                exit $retVal
-        fi
+if [[ ! -f ${FLASHER_PARAM_VALUES[-f]} ]]; then
+    echo "File not found locally. Try to download?"
+    read -ep "Enter Y to proceed, any other entry to exit: " answer
+    [[ $answer == [yY] ]] || exit_with_error
+
+    echo " "
+    echo "Downloading..."
+    echo " "
+    curl --fail --output "${FLASHER_PARAM_VALUES[-f]}" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f ${FLASHER_PARAM_VALUES[-f]} ]]
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Download Error! Please re-run this script..."
+    echo " "
+    echo "Download complete! Checking md5 checksum..."
+    md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
+    [[ -n $md5 ]] || delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${FLASHER_PARAM_VALUES[-f]}" | md5sum --check
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Error comparing checksums! Please re-run this script..."
+    echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device: $deviceName"
-echo " "
-echo "Firmware File: $fileName"
-echo " "
-echo "Are the above device and firmware values correct?"
-read -p "Enter Y to proceed, any other entry to exit: " correctVal
-echo " "
+FLASHER_PARAMS=()
+for param in "${FLASHER_PARAM_LIST[@]}"; do
+    value="${FLASHER_PARAM_VALUES[$param]}"
+    [[ -n $value ]] || continue
+    FLASHER_PARAMS+=( "$param" "$value" )
 
-if [[ $correctVal == [yY] ]]; then
-        echo "Flashing..."
-        echo " "
-        $FLASHER -t 60 -d $deviceName -f "$filePath"
+    pattern="${FLASHER_PARAM_PRINT[$param]-${FLASHER_PARAM_PRINT[default]}}"
+    [[ $value =~ $pattern ]] && printf "%s: %s\n" "${FLASHER_PARAM_NAMES[$param]}" "${BASH_REMATCH}"
+done
 
-        retVal=$?
-        if (( retVal != 0 )); then
-                echo " "
-                echo "Flashing Error! Please re-run this script..."
-                echo " "
-                exit $retVal
-        fi
-else
-        echo "Exiting..."
-        echo " "
-        exit 1
-fi
+echo " "
+echo "Are the above values correct?"
+read -ep "Enter Y to proceed, any other entry to exit: " correctVal
+[[ $correctVal == [yY] ]] || exit_with_error
+
+echo " "
+echo "Flashing..."
+echo " "
+$FLASHER "${FLASHER_PARAMS[@]}"
+exit_on_error "Flashing Error! Please re-run this script..."

--- a/amd64/root/start.sh
+++ b/amd64/root/start.sh
@@ -15,7 +15,7 @@ DECONZ_OPTS="--auto-connect=1 \
         --ws-port=$DECONZ_WS_PORT"
 
 if [ "$DECONZ_VNC_MODE" != 0 ]; then
-  
+
   if [ "$DECONZ_VNC_PORT" -lt 5900 ]; then
     echo "[marthoc/deconz] ERROR - VNC port must be 5900 or greater!"
     exit 1
@@ -23,12 +23,16 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
 
   DECONZ_VNC_DISPLAY=:$(($DECONZ_VNC_PORT - 5900))
   echo "[marthoc/deconz] VNC port: $DECONZ_VNC_PORT"
-  
+
   if [ ! -e /root/.vnc ]; then
     mkdir /root/.vnc
   fi
-  
+
   # Set VNC password
+  if [ "$DECONZ_VNC_PASSWORD_FILE" != 0 ] && [ -f "$DECONZ_VNC_PASSWORD_FILE" ]; then
+      DECONZ_VNC_PASSWORD=$(cat $DECONZ_VNC_PASSWORD_FILE)
+  fi
+
   echo "$DECONZ_VNC_PASSWORD" | tigervncpasswd -f > /root/.vnc/passwd
   chmod 600 /root/.vnc/passwd
 
@@ -37,9 +41,36 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
 
   # Set VNC security
   tigervncserver -SecurityTypes VncAuth,TLSVnc "$DECONZ_VNC_DISPLAY"
-  
+
   # Export VNC display variable
   export DISPLAY=$DECONZ_VNC_DISPLAY
+
+  if [ "$DECONZ_NOVNC_PORT" = 0 ]; then
+    echo "[marthoc/deconz] noVNC Disabled"
+  else
+    if [ "$DECONZ_NOVNC_PORT" -lt 6080 ]; then
+      echo "[marthoc/deconz] ERROR - NOVNC port must be 6080 or greater!"
+      exit 1
+    fi
+
+    # Assert valid SSL certificate
+    NOVNC_CERT="/root/.vnc/novnc.pem"
+    if [ -f "$NOVNC_CERT" ]; then
+      openssl x509 -noout -in "$NOVNC_CERT" -checkend 0 > /dev/null
+      if [ $? != 0 ]; then
+        echo "[marthoc/deconz] The noVNC SSL certificate has expired; generating a new certificate now."
+        rm "$NOVNC_CERT"
+      fi
+    fi
+    if [ ! -f "$NOVNC_CERT" ]; then
+      openssl req -x509 -nodes -newkey rsa:2048 -keyout "$NOVNC_CERT" -out "$NOVNC_CERT" -days 365 -subj "/CN=deconz"
+    fi
+
+    #Start noVNC
+    websockify -D --web=/usr/share/novnc/ --cert="$NOVNC_CERT" $DECONZ_NOVNC_PORT localhost:$DECONZ_VNC_PORT
+    echo "[marthoc/deconz] NOVNC port: $DECONZ_NOVNC_PORT"
+  fi
+
 else
   echo "[marthoc/deconz] VNC Disabled"
   DECONZ_OPTS="$DECONZ_OPTS -platform minimal"

--- a/arm64/Dockerfile
+++ b/arm64/Dockerfile
@@ -1,5 +1,5 @@
 FROM multiarch/qemu-user-static:aarch64 as qemu
-FROM arm64v8/debian:10.6-slim
+FROM arm64v8/ubuntu:20.04
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 
 # Build arguments
@@ -20,7 +20,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DECONZ_VNC_MODE=0 \
     DECONZ_VNC_DISPLAY=0 \
     DECONZ_VNC_PASSWORD=changeme \
+    DECONZ_VNC_PASSWORD_FILE=0 \
     DECONZ_VNC_PORT=5900 \
+    DECONZ_NOVNC_PORT=6080 \
     DECONZ_UPNP=1
 
 # Install deCONZ dependencies
@@ -40,7 +42,9 @@ RUN apt-get update && \
         sqlite3 \
         tigervnc-standalone-server \
         tigervnc-common \
-        wmii \
+        novnc \
+        websockify \
+        openbox \
         xfonts-base \
         xfonts-scalable && \
     apt-get clean && \
@@ -60,6 +64,6 @@ RUN dpkg -i /deconz.deb && \
 
 VOLUME [ "/root/.local/share/dresden-elektronik/deCONZ" ]
 
-EXPOSE ${DECONZ_WEB_PORT} ${DECONZ_WS_PORT} ${DECONZ_VNC_PORT}
+EXPOSE ${DECONZ_WEB_PORT} ${DECONZ_WS_PORT} ${DECONZ_VNC_PORT} ${DECONZ_NOVNC_PORT}
 
 ENTRYPOINT [ "/start.sh" ]

--- a/arm64/root/firmware-update.sh
+++ b/arm64/root/firmware-update.sh
@@ -1,9 +1,108 @@
 #!/bin/bash
 
-VERSION=0.6
+# ===========================
+# Configuration
+# ===========================
+VERSION=0.7
+# ---------------------------
+# Flasher and options
+# ---------------------------
 FLASHER=/usr/bin/GCFFlasher_internal
+FLASHER_PARAM_LIST=( -d -f -s -t -R -B -x )
+typeset -A FLASHER_PARAM_NAMES=( # GCFFlasher <options>
+                                 #  -r              force device reset without programming
+    [-f]="Firmware file"         #  -f <firmware>   flash firmware file
+    [-d]="Device path ."         #  -d <device>     device number or path to use, e.g. 0, /dev/ttyUSB0 or RaspBee
+    [-s]="Serial number"         #  -s <serial>     serial number to use
+    [-t]="Timeout ....."         #  -t <timeout>    retry until timeout (seconds) is reached
+    [-R]="Retries ....."         #  -R <retries>    max. retries
+    [-B]="Baudrate ...."         #  -B <baudrate>   custom baudrate
+                                 #  -l              list devices
+    [-x]="Loglevel ...."         #  -x <loglevel>   debug log level 0, 1, 3
+                                 #  -j <test>       runs a test 1
+                                 #  -h -?           print this help
+)
+typeset -A FLASHER_PARAM_PRINT=(
+    [-f]="[^/]*$"
+    [default]=".*"
+)
+# Default values
+typeset -A FLASHER_PARAM_VALUES=(
+    [-d]="$DECONZ_DEVICE"
+    [-t]="60"
+)
+
+# ---------------------------
+# Firmware details
+# ---------------------------
 FW_PATH=/usr/share/deCONZ/firmware/
-FW_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+
+# ===========================
+# exit functions
+# ===========================
+# ---------------------------
+# Exit the script
+# - on exit print 1st param or "Exiting..." as message
+# - use 2nd param or 1 as exit-code
+# ---------------------------
+function exit_with_error() {
+    typeset msg="${1:-Exiting...}"
+    typeset -i retVal="${2:-1}"
+    printf "\n%s\n\n" "$msg"
+    exit $retVal
+}
+
+# ---------------------------
+# Check last return-code or 2nd param
+# - if non-zero exit with message
+# - on exit print 1st param or "Exiting..." as message
+# ---------------------------
+function exit_on_error() {
+    typeset -i retVal="${2:-$?}"
+    typeset msg="$1"
+    (( retVal == 0 )) || exit_with_error "$msg" $retVal
+}
+
+# ---------------------------
+# Check last return-code or 3rd param
+# - if non-zero exit with message
+# - on exit remove file (1st param) if present
+# - on exit print 2nd param or "Exiting..." as message
+# ---------------------------
+function delete_and_exit_on_error() {
+    typeset -i retVal="${3:-$?}"
+    typeset file="$1"
+    typeset msg="$2"
+    if (( retVal != 0 )); then
+        [[ -f $file ]] && rm "$file"
+        exit_with_error "$msg" $retVal
+    fi
+}
+
+# ---------------------------
+# Check 1st param as user-input
+# - exit script on empty input
+# ---------------------------
+function exit_on_enter() {
+    typeset input="$1"
+    [[ -n $input ]] || exit_with_error
+}
+
+# ===========================
+# utility functions
+# ===========================
+# ---------------------------
+# Parse all options passed to the script.
+# Options of the flasher are valid options.
+# ---------------------------
+function parse_options() {
+    while (( $# > 0)); do
+        [[ -n ${FLASHER_PARAM_NAMES[$1]} ]] || exit_with_error "Unknown argument '$1'. Exiting ..."
+        FLASHER_PARAM_VALUES[$1]="$2"
+        shift 2
+    done
+}
 
 echo "-------------------------------------------------------------------"
 echo " "
@@ -13,6 +112,9 @@ echo "                       Version: $VERSION"
 echo " "
 echo "-------------------------------------------------------------------"
 echo " "
+
+parse_options "$@"
+
 echo " "
 echo "Listing attached devices..."
 echo " "
@@ -22,13 +124,12 @@ $FLASHER -l
 echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
-read -p "Device Path : " deviceName
-echo " "
-if [[ -z "${deviceName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 
+param=-d
+read -ep "${FLASHER_PARAM_NAMES[$param]}: " -i "${FLASHER_PARAM_VALUES[$param]}" FLASHER_PARAM_VALUES[$param]
+exit_on_enter ${FLASHER_PARAM_VALUES[$param]}
+
+echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 echo "Firmware available for flashing:"
@@ -37,74 +138,54 @@ ls -1 "$FW_PATH"
 echo " "
 echo "Enter the firmware file name from above, including extension."
 echo "Alternatively, you may enter the name of a firmware file to download"
-echo "from $FW_BASE"
+echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
-read -p "File Name : " fileName
+param=-f
+read -ep "${FLASHER_PARAM_NAMES[$param]}: " -i "${FLASHER_PARAM_VALUES[$param]##*/}" fileName
+exit_on_enter $fileName
+FLASHER_PARAM_VALUES[$param]="${FW_PATH%/}/$fileName"
+
 echo " "
-if [[ -z "${fileName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
-filePath="${FW_PATH%/}/$fileName"
-if [[ ! -f $filePath ]]; then
-        echo "File not found locally. Try to download?"
-        read -p "Enter Y to proceed, any other entry to exit: " answer
-        echo " "
-        if [[ $answer != [yY] ]]; then
-                echo "Exiting..."
-                exit 1
-        fi
-        echo "Downloading..."
-        echo " "
-        curl --fail --output "$filePath" "${FW_BASE%/}/$fileName"
-        retVal=$?
-        if [[ ! -f $filePath ]] || (( retVal != 0 )); then
-                echo " "
-                echo "Download Error! Please re-run this script..."
-                echo " "
-                [[ -f $filePath ]] && rm "$filePath"
-                exit $(( retVal == 0 ? 1 : retVal ))
-        fi
-        echo " "
-        echo "Download complete! Checking md5 checksum..."
-        md5=$(curl --fail --silent "${FW_BASE%/}/${fileName}.md5")
-        echo "${md5% *} ${filePath}" | md5sum --check
-        retVal=$?
-        echo " "
-        if (( retVal != 0 )); then
-                echo "Error comparing checksums! Please re-run this script..."
-                echo " "
-                rm "$filePath"
-                exit $retVal
-        fi
+if [[ ! -f ${FLASHER_PARAM_VALUES[-f]} ]]; then
+    echo "File not found locally. Try to download?"
+    read -ep "Enter Y to proceed, any other entry to exit: " answer
+    [[ $answer == [yY] ]] || exit_with_error
+
+    echo " "
+    echo "Downloading..."
+    echo " "
+    curl --fail --output "${FLASHER_PARAM_VALUES[-f]}" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f ${FLASHER_PARAM_VALUES[-f]} ]]
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Download Error! Please re-run this script..."
+    echo " "
+    echo "Download complete! Checking md5 checksum..."
+    md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
+    [[ -n $md5 ]] || delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${FLASHER_PARAM_VALUES[-f]}" | md5sum --check
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Error comparing checksums! Please re-run this script..."
+    echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device: $deviceName"
-echo " "
-echo "Firmware File: $fileName"
-echo " "
-echo "Are the above device and firmware values correct?"
-read -p "Enter Y to proceed, any other entry to exit: " correctVal
-echo " "
+FLASHER_PARAMS=()
+for param in "${FLASHER_PARAM_LIST[@]}"; do
+    value="${FLASHER_PARAM_VALUES[$param]}"
+    [[ -n $value ]] || continue
+    FLASHER_PARAMS+=( "$param" "$value" )
 
-if [[ $correctVal == [yY] ]]; then
-        echo "Flashing..."
-        echo " "
-        $FLASHER -t 60 -d $deviceName -f "$filePath"
+    pattern="${FLASHER_PARAM_PRINT[$param]-${FLASHER_PARAM_PRINT[default]}}"
+    [[ $value =~ $pattern ]] && printf "%s: %s\n" "${FLASHER_PARAM_NAMES[$param]}" "${BASH_REMATCH}"
+done
 
-        retVal=$?
-        if (( retVal != 0 )); then
-                echo " "
-                echo "Flashing Error! Please re-run this script..."
-                echo " "
-                exit $retVal
-        fi
-else
-        echo "Exiting..."
-        echo " "
-        exit 1
-fi
+echo " "
+echo "Are the above values correct?"
+read -ep "Enter Y to proceed, any other entry to exit: " correctVal
+[[ $correctVal == [yY] ]] || exit_with_error
+
+echo " "
+echo "Flashing..."
+echo " "
+$FLASHER "${FLASHER_PARAMS[@]}"
+exit_on_error "Flashing Error! Please re-run this script..."

--- a/arm64/root/start.sh
+++ b/arm64/root/start.sh
@@ -15,7 +15,7 @@ DECONZ_OPTS="--auto-connect=1 \
         --ws-port=$DECONZ_WS_PORT"
 
 if [ "$DECONZ_VNC_MODE" != 0 ]; then
-  
+
   if [ "$DECONZ_VNC_PORT" -lt 5900 ]; then
     echo "[marthoc/deconz] ERROR - VNC port must be 5900 or greater!"
     exit 1
@@ -23,12 +23,16 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
 
   DECONZ_VNC_DISPLAY=:$(($DECONZ_VNC_PORT - 5900))
   echo "[marthoc/deconz] VNC port: $DECONZ_VNC_PORT"
-  
+
   if [ ! -e /root/.vnc ]; then
     mkdir /root/.vnc
   fi
-  
+
   # Set VNC password
+  if [ "$DECONZ_VNC_PASSWORD_FILE" != 0 ] && [ -f "$DECONZ_VNC_PASSWORD_FILE" ]; then
+      DECONZ_VNC_PASSWORD=$(cat $DECONZ_VNC_PASSWORD_FILE)
+  fi
+
   echo "$DECONZ_VNC_PASSWORD" | tigervncpasswd -f > /root/.vnc/passwd
   chmod 600 /root/.vnc/passwd
 
@@ -37,9 +41,36 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
 
   # Set VNC security
   tigervncserver -SecurityTypes VncAuth,TLSVnc "$DECONZ_VNC_DISPLAY"
-  
+
   # Export VNC display variable
   export DISPLAY=$DECONZ_VNC_DISPLAY
+
+  if [ "$DECONZ_NOVNC_PORT" = 0 ]; then
+    echo "[marthoc/deconz] noVNC Disabled"
+  else
+    if [ "$DECONZ_NOVNC_PORT" -lt 6080 ]; then
+      echo "[marthoc/deconz] ERROR - NOVNC port must be 6080 or greater!"
+      exit 1
+    fi
+
+    # Assert valid SSL certificate
+    NOVNC_CERT="/root/.vnc/novnc.pem"
+    if [ -f "$NOVNC_CERT" ]; then
+      openssl x509 -noout -in "$NOVNC_CERT" -checkend 0 > /dev/null
+      if [ $? != 0 ]; then
+        echo "[marthoc/deconz] The noVNC SSL certificate has expired; generating a new certificate now."
+        rm "$NOVNC_CERT"
+      fi
+    fi
+    if [ ! -f "$NOVNC_CERT" ]; then
+      openssl req -x509 -nodes -newkey rsa:2048 -keyout "$NOVNC_CERT" -out "$NOVNC_CERT" -days 365 -subj "/CN=deconz"
+    fi
+
+    #Start noVNC
+    websockify -D --web=/usr/share/novnc/ --cert="$NOVNC_CERT" $DECONZ_NOVNC_PORT localhost:$DECONZ_VNC_PORT
+    echo "[marthoc/deconz] NOVNC port: $DECONZ_NOVNC_PORT"
+  fi
+
 else
   echo "[marthoc/deconz] VNC Disabled"
   DECONZ_OPTS="$DECONZ_OPTS -platform minimal"

--- a/armv7/Dockerfile
+++ b/armv7/Dockerfile
@@ -1,5 +1,5 @@
 FROM multiarch/qemu-user-static:arm as qemu
-FROM arm32v7/debian:10.6-slim
+FROM arm32v7/ubuntu:20.04
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
 
 # Build arguments
@@ -20,7 +20,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DECONZ_VNC_MODE=0 \
     DECONZ_VNC_DISPLAY=0 \
     DECONZ_VNC_PASSWORD=changeme \
+    DECONZ_VNC_PASSWORD_FILE=0 \
     DECONZ_VNC_PORT=5900 \
+    DECONZ_NOVNC_PORT=6080 \
     DECONZ_UPNP=1
 
 # Install deCONZ dependencies (except for WiringPi)
@@ -40,7 +42,9 @@ RUN apt-get update && \
         sqlite3 \
         tigervnc-standalone-server \
         tigervnc-common \
-        wmii \
+        novnc \
+        websockify \
+        openbox \
         xfonts-base \
         xfonts-scalable && \
     apt-get clean && \
@@ -65,6 +69,6 @@ RUN dpkg -i /deconz.deb && \
 
 VOLUME [ "/root/.local/share/dresden-elektronik/deCONZ" ]
 
-EXPOSE ${DECONZ_WEB_PORT} ${DECONZ_WS_PORT} ${DECONZ_VNC_PORT}
+EXPOSE ${DECONZ_WEB_PORT} ${DECONZ_WS_PORT} ${DECONZ_VNC_PORT} ${DECONZ_NOVNC_PORT}
 
 ENTRYPOINT [ "/start.sh" ]

--- a/armv7/root/firmware-update.sh
+++ b/armv7/root/firmware-update.sh
@@ -1,9 +1,108 @@
 #!/bin/bash
 
-VERSION=0.6
+# ===========================
+# Configuration
+# ===========================
+VERSION=0.7
+# ---------------------------
+# Flasher and options
+# ---------------------------
 FLASHER=/usr/bin/GCFFlasher_internal
+FLASHER_PARAM_LIST=( -d -f -s -t -R -B -x )
+typeset -A FLASHER_PARAM_NAMES=( # GCFFlasher <options>
+                                 #  -r              force device reset without programming
+    [-f]="Firmware file"         #  -f <firmware>   flash firmware file
+    [-d]="Device path ."         #  -d <device>     device number or path to use, e.g. 0, /dev/ttyUSB0 or RaspBee
+    [-s]="Serial number"         #  -s <serial>     serial number to use
+    [-t]="Timeout ....."         #  -t <timeout>    retry until timeout (seconds) is reached
+    [-R]="Retries ....."         #  -R <retries>    max. retries
+    [-B]="Baudrate ...."         #  -B <baudrate>   custom baudrate
+                                 #  -l              list devices
+    [-x]="Loglevel ...."         #  -x <loglevel>   debug log level 0, 1, 3
+                                 #  -j <test>       runs a test 1
+                                 #  -h -?           print this help
+)
+typeset -A FLASHER_PARAM_PRINT=(
+    [-f]="[^/]*$"
+    [default]=".*"
+)
+# Default values
+typeset -A FLASHER_PARAM_VALUES=(
+    [-d]="$DECONZ_DEVICE"
+    [-t]="60"
+)
+
+# ---------------------------
+# Firmware details
+# ---------------------------
 FW_PATH=/usr/share/deCONZ/firmware/
-FW_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+FW_ONLINE_BASE=http://deconz.dresden-elektronik.de/deconz-firmware/
+
+# ===========================
+# exit functions
+# ===========================
+# ---------------------------
+# Exit the script
+# - on exit print 1st param or "Exiting..." as message
+# - use 2nd param or 1 as exit-code
+# ---------------------------
+function exit_with_error() {
+    typeset msg="${1:-Exiting...}"
+    typeset -i retVal="${2:-1}"
+    printf "\n%s\n\n" "$msg"
+    exit $retVal
+}
+
+# ---------------------------
+# Check last return-code or 2nd param
+# - if non-zero exit with message
+# - on exit print 1st param or "Exiting..." as message
+# ---------------------------
+function exit_on_error() {
+    typeset -i retVal="${2:-$?}"
+    typeset msg="$1"
+    (( retVal == 0 )) || exit_with_error "$msg" $retVal
+}
+
+# ---------------------------
+# Check last return-code or 3rd param
+# - if non-zero exit with message
+# - on exit remove file (1st param) if present
+# - on exit print 2nd param or "Exiting..." as message
+# ---------------------------
+function delete_and_exit_on_error() {
+    typeset -i retVal="${3:-$?}"
+    typeset file="$1"
+    typeset msg="$2"
+    if (( retVal != 0 )); then
+        [[ -f $file ]] && rm "$file"
+        exit_with_error "$msg" $retVal
+    fi
+}
+
+# ---------------------------
+# Check 1st param as user-input
+# - exit script on empty input
+# ---------------------------
+function exit_on_enter() {
+    typeset input="$1"
+    [[ -n $input ]] || exit_with_error
+}
+
+# ===========================
+# utility functions
+# ===========================
+# ---------------------------
+# Parse all options passed to the script.
+# Options of the flasher are valid options.
+# ---------------------------
+function parse_options() {
+    while (( $# > 0)); do
+        [[ -n ${FLASHER_PARAM_NAMES[$1]} ]] || exit_with_error "Unknown argument '$1'. Exiting ..."
+        FLASHER_PARAM_VALUES[$1]="$2"
+        shift 2
+    done
+}
 
 echo "-------------------------------------------------------------------"
 echo " "
@@ -13,6 +112,9 @@ echo "                       Version: $VERSION"
 echo " "
 echo "-------------------------------------------------------------------"
 echo " "
+
+parse_options "$@"
+
 echo " "
 echo "Listing attached devices..."
 echo " "
@@ -22,13 +124,12 @@ $FLASHER -l
 echo " "
 echo "Enter the full device path, or press Enter now to exit."
 echo " "
-read -p "Device Path : " deviceName
-echo " "
-if [[ -z "${deviceName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
 
+param=-d
+read -ep "${FLASHER_PARAM_NAMES[$param]}: " -i "${FLASHER_PARAM_VALUES[$param]}" FLASHER_PARAM_VALUES[$param]
+exit_on_enter ${FLASHER_PARAM_VALUES[$param]}
+
+echo " "
 echo "-------------------------------------------------------------------"
 echo " "
 echo "Firmware available for flashing:"
@@ -37,74 +138,54 @@ ls -1 "$FW_PATH"
 echo " "
 echo "Enter the firmware file name from above, including extension."
 echo "Alternatively, you may enter the name of a firmware file to download"
-echo "from $FW_BASE"
+echo "from $FW_ONLINE_BASE"
 echo "or press Enter now to exit."
 echo " "
 
-read -p "File Name : " fileName
+param=-f
+read -ep "${FLASHER_PARAM_NAMES[$param]}: " -i "${FLASHER_PARAM_VALUES[$param]##*/}" fileName
+exit_on_enter $fileName
+FLASHER_PARAM_VALUES[$param]="${FW_PATH%/}/$fileName"
+
 echo " "
-if [[ -z "${fileName// }" ]]; then
-        echo "Exiting..."
-        exit 1
-fi
-filePath="${FW_PATH%/}/$fileName"
-if [[ ! -f $filePath ]]; then
-        echo "File not found locally. Try to download?"
-        read -p "Enter Y to proceed, any other entry to exit: " answer
-        echo " "
-        if [[ $answer != [yY] ]]; then
-                echo "Exiting..."
-                exit 1
-        fi
-        echo "Downloading..."
-        echo " "
-        curl --fail --output "$filePath" "${FW_BASE%/}/$fileName"
-        retVal=$?
-        if [[ ! -f $filePath ]] || (( retVal != 0 )); then
-                echo " "
-                echo "Download Error! Please re-run this script..."
-                echo " "
-                [[ -f $filePath ]] && rm "$filePath"
-                exit $(( retVal == 0 ? 1 : retVal ))
-        fi
-        echo " "
-        echo "Download complete! Checking md5 checksum..."
-        md5=$(curl --fail --silent "${FW_BASE%/}/${fileName}.md5")
-        echo "${md5% *} ${filePath}" | md5sum --check
-        retVal=$?
-        echo " "
-        if (( retVal != 0 )); then
-                echo "Error comparing checksums! Please re-run this script..."
-                echo " "
-                rm "$filePath"
-                exit $retVal
-        fi
+if [[ ! -f ${FLASHER_PARAM_VALUES[-f]} ]]; then
+    echo "File not found locally. Try to download?"
+    read -ep "Enter Y to proceed, any other entry to exit: " answer
+    [[ $answer == [yY] ]] || exit_with_error
+
+    echo " "
+    echo "Downloading..."
+    echo " "
+    curl --fail --output "${FLASHER_PARAM_VALUES[-f]}" "${FW_ONLINE_BASE%/}/$fileName" && [[ -f ${FLASHER_PARAM_VALUES[-f]} ]]
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Download Error! Please re-run this script..."
+    echo " "
+    echo "Download complete! Checking md5 checksum..."
+    md5=$(curl --fail --silent "${FW_ONLINE_BASE%/}/${fileName}.md5")
+    [[ -n $md5 ]] || delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Checksum file '${fileName}.md5' not found! Please re-run this script..."
+    echo "${md5% *} ${FLASHER_PARAM_VALUES[-f]}" | md5sum --check
+    delete_and_exit_on_error "${FLASHER_PARAM_VALUES[-f]}" "Error comparing checksums! Please re-run this script..."
+    echo " "
 fi
 
 echo "-------------------------------------------------------------------"
 echo " "
-echo "Device: $deviceName"
-echo " "
-echo "Firmware File: $fileName"
-echo " "
-echo "Are the above device and firmware values correct?"
-read -p "Enter Y to proceed, any other entry to exit: " correctVal
-echo " "
+FLASHER_PARAMS=()
+for param in "${FLASHER_PARAM_LIST[@]}"; do
+    value="${FLASHER_PARAM_VALUES[$param]}"
+    [[ -n $value ]] || continue
+    FLASHER_PARAMS+=( "$param" "$value" )
 
-if [[ $correctVal == [yY] ]]; then
-        echo "Flashing..."
-        echo " "
-        $FLASHER -t 60 -d $deviceName -f "$filePath"
+    pattern="${FLASHER_PARAM_PRINT[$param]-${FLASHER_PARAM_PRINT[default]}}"
+    [[ $value =~ $pattern ]] && printf "%s: %s\n" "${FLASHER_PARAM_NAMES[$param]}" "${BASH_REMATCH}"
+done
 
-        retVal=$?
-        if (( retVal != 0 )); then
-                echo " "
-                echo "Flashing Error! Please re-run this script..."
-                echo " "
-                exit $retVal
-        fi
-else
-        echo "Exiting..."
-        echo " "
-        exit 1
-fi
+echo " "
+echo "Are the above values correct?"
+read -ep "Enter Y to proceed, any other entry to exit: " correctVal
+[[ $correctVal == [yY] ]] || exit_with_error
+
+echo " "
+echo "Flashing..."
+echo " "
+$FLASHER "${FLASHER_PARAMS[@]}"
+exit_on_error "Flashing Error! Please re-run this script..."

--- a/armv7/root/start.sh
+++ b/armv7/root/start.sh
@@ -15,7 +15,7 @@ DECONZ_OPTS="--auto-connect=1 \
         --ws-port=$DECONZ_WS_PORT"
 
 if [ "$DECONZ_VNC_MODE" != 0 ]; then
-  
+
   if [ "$DECONZ_VNC_PORT" -lt 5900 ]; then
     echo "[marthoc/deconz] ERROR - VNC port must be 5900 or greater!"
     exit 1
@@ -23,12 +23,16 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
 
   DECONZ_VNC_DISPLAY=:$(($DECONZ_VNC_PORT - 5900))
   echo "[marthoc/deconz] VNC port: $DECONZ_VNC_PORT"
-  
+
   if [ ! -e /root/.vnc ]; then
     mkdir /root/.vnc
   fi
-  
+
   # Set VNC password
+  if [ "$DECONZ_VNC_PASSWORD_FILE" != 0 ] && [ -f "$DECONZ_VNC_PASSWORD_FILE" ]; then
+      DECONZ_VNC_PASSWORD=$(cat $DECONZ_VNC_PASSWORD_FILE)
+  fi
+
   echo "$DECONZ_VNC_PASSWORD" | tigervncpasswd -f > /root/.vnc/passwd
   chmod 600 /root/.vnc/passwd
 
@@ -37,9 +41,36 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
 
   # Set VNC security
   tigervncserver -SecurityTypes VncAuth,TLSVnc "$DECONZ_VNC_DISPLAY"
-  
+
   # Export VNC display variable
   export DISPLAY=$DECONZ_VNC_DISPLAY
+
+  if [ "$DECONZ_NOVNC_PORT" = 0 ]; then
+    echo "[marthoc/deconz] noVNC Disabled"
+  else
+    if [ "$DECONZ_NOVNC_PORT" -lt 6080 ]; then
+      echo "[marthoc/deconz] ERROR - NOVNC port must be 6080 or greater!"
+      exit 1
+    fi
+
+    # Assert valid SSL certificate
+    NOVNC_CERT="/root/.vnc/novnc.pem"
+    if [ -f "$NOVNC_CERT" ]; then
+      openssl x509 -noout -in "$NOVNC_CERT" -checkend 0 > /dev/null
+      if [ $? != 0 ]; then
+        echo "[marthoc/deconz] The noVNC SSL certificate has expired; generating a new certificate now."
+        rm "$NOVNC_CERT"
+      fi
+    fi
+    if [ ! -f "$NOVNC_CERT" ]; then
+      openssl req -x509 -nodes -newkey rsa:2048 -keyout "$NOVNC_CERT" -out "$NOVNC_CERT" -days 365 -subj "/CN=deconz"
+    fi
+
+    #Start noVNC
+    websockify -D --web=/usr/share/novnc/ --cert="$NOVNC_CERT" $DECONZ_NOVNC_PORT localhost:$DECONZ_VNC_PORT
+    echo "[marthoc/deconz] NOVNC port: $DECONZ_NOVNC_PORT"
+  fi
+
 else
   echo "[marthoc/deconz] VNC Disabled"
   DECONZ_OPTS="$DECONZ_OPTS -platform minimal"


### PR DESCRIPTION
Omnibus update for the image, featuring:
- New multiarch version tag (e.g. specify a version number as the image tag, and the correct version will be pulled for your arch. Closes #350.)
- Allows the user to specify additional command line options for GCFFlasher via the command line (Closes #318).
- Adds support for noVNC, allowing the user to access the VNC session through a web browser.
- Changes the image base to Ubuntu 20.04, for better support and to align with the requirements of deCONZ.
- Adds support for using Docker secrets or a password file to store the VNC password.