### PR TITLE
Move deCONZ volume and use a non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker run -d \
     --net=host \
     --restart=always \
     -v /etc/localtime:/etc/localtime:ro \
-    -v /opt/deconz:/root/.local/share/dresden-elektronik/deCONZ \
+    -v /opt/deconz:/opt/deCONZ \
     --device=/dev/ttyUSB0 \
     marthoc/deconz
 ```
@@ -54,7 +54,7 @@ docker run -d \
 |`--net=host`|Uses host networking mode for proper uPNP functionality; by default, the web UIs and REST API listen on port 80 and the websockets service listens on port 443. If these ports conflict with other services on your host, you can change them through the environment variables DECONZ_WEB_PORT and DECONZ_WS_PORT described below.|
 |`--restart=always`|Start the container when Docker starts (i.e. on boot/reboot).|
 |`-v /etc/localtime:/etc/localtime:ro`|Ensure the container has the correct local time (alternatively, use the TZ environment variable, see below).|
-|`-v /opt/deconz:/root/.local/share/dresden-elektronik/deCONZ`|Bind mount /opt/deconz (or the directory of your choice) into the container for persistent storage.|
+|`-v /opt/deconz:/opt/deCONZ`|Bind mount /opt/deconz (or the directory of your choice) into the container for persistent storage.|
 |`--device=/dev/ttyUSB0`|Pass the serial device at ttyUSB0 into the container for use by deCONZ (you may need to investigate which device name is assigned to your device depending on if you are also using other usb serial devices; by default ConBee = /dev/ttyUSB0, Conbee II = /dev/ttyACM0, RaspBee = /dev/ttyAMA0 or /dev/ttyS0).|
 |`marthoc/deconz`|This image uses a manifest list for multiarch support; specifying marthoc/deconz:latest or marthoc/deconz:stable will pull the correct version for your arch.|
 
@@ -79,6 +79,9 @@ Use these environment variables to change the default behaviour of the container
 |`-e DECONZ_VNC_PASSWORD_FILE=/var/secrets/my_secret`|Per default this is disabled and DECONZ_VNC_PASSWORD is used. Details on creating secrets for use with Docker containers can be found in the [corresponding section from the official documentation](https://docs.docker.com/engine/swarm/secrets/) |
 |`-e DECONZ_NOVNC_PORT=6080`|Default port for noVNC is 6080; this option can be used to change this port; setting the port to `0` will disable the noVNC functionality|
 |`-e DECONZ_UPNP=0`|Set this option to 0 to disable uPNP, see: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/274|
+|`-e DECONZ_UID=1000`|Set the user id of deCONZ volume|
+|`-e DECONZ_GID=1000`|Set the group id of deCONZ volume|
+|`-e DECONZ_START_VERBOSE=0`|Set this option to 0 to disable verbose of start script, set to 1 to enable `set -x` logging|
 
 #### Docker-Compose
 
@@ -93,7 +96,7 @@ services:
     network_mode: host
     restart: always
     volumes:
-      - /opt/deconz:/root/.local/share/dresden-elektronik/deCONZ
+      - /opt/deconz:/opt/deCONZ
     devices:
       - /dev/ttyUSB0
     environment:
@@ -118,7 +121,7 @@ docker run -d \
     -p 80:80 \
     -p 443:443 \
     --restart=always \
-    -v /opt/deconz:/root/.local/share/dresden-elektronik/deCONZ \
+    -v /opt/deconz:/opt/deCONZ \
     --device=/dev/ttyUSB0 \
     -e DECONZ_WEB_PORT=80 \
     -e DECONZ_WS_PORT=443 \

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -21,11 +21,15 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DECONZ_VNC_PASSWORD_FILE=0 \
     DECONZ_VNC_PORT=5900 \
     DECONZ_NOVNC_PORT=6080 \
-    DECONZ_UPNP=1
+    DECONZ_UPNP=1 \
+    DECONZ_UID=1000 \
+    DECONZ_GID=1000 \
+    DECONZ_START_VERBOSE=0
 
 # Install deCONZ dependencies
 RUN apt-get update && \
     apt-get install -y \
+        sudo \
         curl \
         kmod \
         libcap2-bin \
@@ -61,14 +65,21 @@ COPY root /
 RUN chmod +x /start.sh && \
     chmod +x /firmware-update.sh
 
-# Add deCONZ, install deCONZ, make OTAU dir
+# Make user
+RUN groupadd -g ${DECONZ_GID} "deconz" && \
+    useradd -u ${DECONZ_UID} -g "deconz" -G dialout -ms /bin/bash "deconz" && \
+    mkdir -p /opt/deCONZ/otau && \
+    mkdir -p /opt/deCONZ/vnc && \
+    mkdir -p /opt/deCONZ/data
+
+# Add deCONZ, install deCONZ
 ADD http://deconz.dresden-elektronik.de/ubuntu/${CHANNEL}/deconz-${DECONZ_VERSION}-qt5.deb /deconz.deb
 RUN dpkg -i /deconz.deb && \
-    rm -f /deconz.deb && \
-    mkdir /root/otau && \
-    chown root:root /usr/bin/deCONZ*
+    chown root:root /usr/bin/deCONZ* && \
+    setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/deCONZ && \
+    rm -f /deconz.deb
 
-VOLUME [ "/root/.local/share/dresden-elektronik/deCONZ" ]
+VOLUME [ "/opt/deCONZ" ]
 
 EXPOSE ${DECONZ_WEB_PORT} ${DECONZ_WS_PORT} ${DECONZ_VNC_PORT} ${DECONZ_NOVNC_PORT}
 

--- a/amd64/root/start.sh
+++ b/amd64/root/start.sh
@@ -109,7 +109,7 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
       openssl req -x509 -nodes -newkey rsa:2048 -keyout "$NOVNC_CERT" -out "$NOVNC_CERT" -days 365 -subj "/CN=deconz"
     fi
 
-    chmod deconz:deconz $NOVNC_CERT
+    chown deconz:deconz $NOVNC_CERT
 
     #Start noVNC
     sudo -u deconz websockify -D --web=/usr/share/novnc/ --cert="$NOVNC_CERT" $DECONZ_NOVNC_PORT localhost:$DECONZ_VNC_PORT

--- a/amd64/root/start.sh
+++ b/amd64/root/start.sh
@@ -33,16 +33,16 @@ echo "[marthoc/deconz] Checking device group ID"
 if [ "$DECONZ_DEVICE" != 0 ]; then
   DEVICE=$DECONZ_DEVICE
 else
- if [ -f /dev/ttyUSB0 ]; then
+ if [ -e /dev/ttyUSB0 ]; then
    DEVICE=/dev/ttyUSB0
  fi
- if [ -f /dev/ttyACM0 ]; then
+ if [ -e /dev/ttyACM0 ]; then
    DEVICE=/dev/ttyACM0
  fi
- if [ -f /dev/ttyAMA0 ]; then
+ if [ -e /dev/ttyAMA0 ]; then
    DEVICE=/dev/ttyAMA0
  fi
- if [ -f /dev/ttyS0 ]; then
+ if [ -e /dev/ttyS0 ]; then
    DEVICE=/dev/ttyS0
  fi
 fi

--- a/arm64/Dockerfile
+++ b/arm64/Dockerfile
@@ -23,11 +23,15 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DECONZ_VNC_PASSWORD_FILE=0 \
     DECONZ_VNC_PORT=5900 \
     DECONZ_NOVNC_PORT=6080 \
-    DECONZ_UPNP=1
+    DECONZ_UPNP=1 \
+    DECONZ_UID=1000 \
+    DECONZ_GID=1000 \
+    DECONZ_START_VERBOSE=0
 
 # Install deCONZ dependencies
 RUN apt-get update && \
     apt-get install -y \
+        sudo \
         curl \
         kmod \
         libcap2-bin \
@@ -55,14 +59,21 @@ COPY root /
 RUN chmod +x /start.sh && \
     chmod +x /firmware-update.sh
 
-# Add deCONZ, install deCONZ, make OTAU dir
+# Make user
+RUN groupadd -g ${DECONZ_GID} "deconz" && \
+    useradd -u ${DECONZ_UID} -g "deconz" -G dialout -ms /bin/bash "deconz" && \
+    mkdir -p /opt/deCONZ/otau && \
+    mkdir -p /opt/deCONZ/vnc && \
+    mkdir -p /opt/deCONZ/data
+
+# Add deCONZ, install deCONZ
 ADD http://deconz.dresden-elektronik.de/debian/${CHANNEL}/deconz_${DECONZ_VERSION}-debian-stretch-${CHANNEL}_arm64.deb /deconz.deb
 RUN dpkg -i /deconz.deb && \
-    rm -f /deconz.deb && \
-    mkdir /root/otau && \
-    chown root:root /usr/bin/deCONZ*
+    chown root:root /usr/bin/deCONZ* && \
+    setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/deCONZ && \
+    rm -f /deconz.deb
 
-VOLUME [ "/root/.local/share/dresden-elektronik/deCONZ" ]
+VOLUME [ "/opt/deCONZ" ]
 
 EXPOSE ${DECONZ_WEB_PORT} ${DECONZ_WS_PORT} ${DECONZ_VNC_PORT} ${DECONZ_NOVNC_PORT}
 

--- a/arm64/root/start.sh
+++ b/arm64/root/start.sh
@@ -109,7 +109,7 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
       openssl req -x509 -nodes -newkey rsa:2048 -keyout "$NOVNC_CERT" -out "$NOVNC_CERT" -days 365 -subj "/CN=deconz"
     fi
 
-    chmod deconz:deconz $NOVNC_CERT
+    chown deconz:deconz $NOVNC_CERT
 
     #Start noVNC
     sudo -u deconz websockify -D --web=/usr/share/novnc/ --cert="$NOVNC_CERT" $DECONZ_NOVNC_PORT localhost:$DECONZ_VNC_PORT

--- a/arm64/root/start.sh
+++ b/arm64/root/start.sh
@@ -33,16 +33,16 @@ echo "[marthoc/deconz] Checking device group ID"
 if [ "$DECONZ_DEVICE" != 0 ]; then
   DEVICE=$DECONZ_DEVICE
 else
- if [ -f /dev/ttyUSB0 ]; then
+ if [ -e /dev/ttyUSB0 ]; then
    DEVICE=/dev/ttyUSB0
  fi
- if [ -f /dev/ttyACM0 ]; then
+ if [ -e /dev/ttyACM0 ]; then
    DEVICE=/dev/ttyACM0
  fi
- if [ -f /dev/ttyAMA0 ]; then
+ if [ -e /dev/ttyAMA0 ]; then
    DEVICE=/dev/ttyAMA0
  fi
- if [ -f /dev/ttyS0 ]; then
+ if [ -e /dev/ttyS0 ]; then
    DEVICE=/dev/ttyS0
  fi
 fi

--- a/armv7/Dockerfile
+++ b/armv7/Dockerfile
@@ -23,11 +23,15 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DECONZ_VNC_PASSWORD_FILE=0 \
     DECONZ_VNC_PORT=5900 \
     DECONZ_NOVNC_PORT=6080 \
-    DECONZ_UPNP=1
+    DECONZ_UPNP=1 \
+    DECONZ_UID=1000 \
+    DECONZ_GID=1000 \
+    DECONZ_START_VERBOSE=0
 
 # Install deCONZ dependencies (except for WiringPi)
 RUN apt-get update && \
     apt-get install -y \
+        sudo \
         curl \
         kmod \
         libcap2-bin \
@@ -60,14 +64,21 @@ COPY root /
 RUN chmod +x /start.sh && \
     chmod +x /firmware-update.sh
 
-# Add deCONZ, install deCONZ, make OTAU dir
+# Make user
+RUN groupadd -g ${DECONZ_GID} "deconz" && \
+    useradd -u ${DECONZ_UID} -g "deconz" -G dialout -ms /bin/bash "deconz" && \
+    mkdir -p /opt/deCONZ/otau && \
+    mkdir -p /opt/deCONZ/vnc && \
+    mkdir -p /opt/deCONZ/data
+
+# Add deCONZ, install deCONZ
 ADD http://deconz.dresden-elektronik.de/raspbian/${CHANNEL}/deconz-${DECONZ_VERSION}-qt5.deb /deconz.deb
 RUN dpkg -i /deconz.deb && \
-    rm -f /deconz.deb && \
-    mkdir /root/otau && \
-    chown root:root /usr/bin/deCONZ*
+    chown root:root /usr/bin/deCONZ* && \
+    setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/deCONZ && \
+    rm -f /deconz.deb
 
-VOLUME [ "/root/.local/share/dresden-elektronik/deCONZ" ]
+VOLUME [ "/opt/deCONZ" ]
 
 EXPOSE ${DECONZ_WEB_PORT} ${DECONZ_WS_PORT} ${DECONZ_VNC_PORT} ${DECONZ_NOVNC_PORT}
 

--- a/armv7/root/start.sh
+++ b/armv7/root/start.sh
@@ -109,7 +109,7 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
       openssl req -x509 -nodes -newkey rsa:2048 -keyout "$NOVNC_CERT" -out "$NOVNC_CERT" -days 365 -subj "/CN=deconz"
     fi
 
-    chmod deconz:deconz $NOVNC_CERT
+    chown deconz:deconz $NOVNC_CERT
 
     #Start noVNC
     sudo -u deconz websockify -D --web=/usr/share/novnc/ --cert="$NOVNC_CERT" $DECONZ_NOVNC_PORT localhost:$DECONZ_VNC_PORT

--- a/armv7/root/start.sh
+++ b/armv7/root/start.sh
@@ -33,16 +33,16 @@ echo "[marthoc/deconz] Checking device group ID"
 if [ "$DECONZ_DEVICE" != 0 ]; then
   DEVICE=$DECONZ_DEVICE
 else
- if [ -f /dev/ttyUSB0 ]; then
+ if [ -e /dev/ttyUSB0 ]; then
    DEVICE=/dev/ttyUSB0
  fi
- if [ -f /dev/ttyACM0 ]; then
+ if [ -e /dev/ttyACM0 ]; then
    DEVICE=/dev/ttyACM0
  fi
- if [ -f /dev/ttyAMA0 ]; then
+ if [ -e /dev/ttyAMA0 ]; then
    DEVICE=/dev/ttyAMA0
  fi
- if [ -f /dev/ttyS0 ]; then
+ if [ -e /dev/ttyS0 ]; then
    DEVICE=/dev/ttyS0
  fi
 fi


### PR DESCRIPTION
This PR features the move of the volume to /opt/deCONZ with sub folders (otau, vnc, appdata), for editing the vnc config or manually adding a certificate. Secondly deCONZ and the VNC tools now run as a non-root user. The UID and GID can be change using environment parameters. 