### PR TITLE
Download firmware over https

### DIFF
--- a/amd64/root/firmware-update.sh
+++ b/amd64/root/firmware-update.sh
@@ -37,8 +37,8 @@ typeset -A FLASHER_PARAM_VALUES=(
 # ---------------------------
 FW_PATH=/usr/share/deCONZ/firmware/
 typeset -A FW_ONLINE_BASES=(
-    [stable]="http://deconz.dresden-elektronik.de/deconz-firmware/"
-    [beta]="http://deconz.dresden-elektronik.de/deconz-firmware/beta/"
+    [stable]="https://deconz.dresden-elektronik.de/deconz-firmware/"
+    [beta]="https://deconz.dresden-elektronik.de/deconz-firmware/beta/"
 )
 FW_ONLINE_BASE_ORDER=( stable beta )
 

--- a/arm64/root/firmware-update.sh
+++ b/arm64/root/firmware-update.sh
@@ -37,8 +37,8 @@ typeset -A FLASHER_PARAM_VALUES=(
 # ---------------------------
 FW_PATH=/usr/share/deCONZ/firmware/
 typeset -A FW_ONLINE_BASES=(
-    [stable]="http://deconz.dresden-elektronik.de/deconz-firmware/"
-    [beta]="http://deconz.dresden-elektronik.de/deconz-firmware/beta/"
+    [stable]="https://deconz.dresden-elektronik.de/deconz-firmware/"
+    [beta]="https://deconz.dresden-elektronik.de/deconz-firmware/beta/"
 )
 FW_ONLINE_BASE_ORDER=( stable beta )
 

--- a/armv7/root/firmware-update.sh
+++ b/armv7/root/firmware-update.sh
@@ -37,8 +37,8 @@ typeset -A FLASHER_PARAM_VALUES=(
 # ---------------------------
 FW_PATH=/usr/share/deCONZ/firmware/
 typeset -A FW_ONLINE_BASES=(
-    [stable]="http://deconz.dresden-elektronik.de/deconz-firmware/"
-    [beta]="http://deconz.dresden-elektronik.de/deconz-firmware/beta/"
+    [stable]="https://deconz.dresden-elektronik.de/deconz-firmware/"
+    [beta]="https://deconz.dresden-elektronik.de/deconz-firmware/beta/"
 )
 FW_ONLINE_BASE_ORDER=( stable beta )
 


### PR DESCRIPTION
For better security it would make sense to download the firmware via https instead of http, right?
The deconz server supports https. At least in a browser.

I first wanted to open an issue for this but decided to send a pull request instead. Be warned though: Due to some fun with docker network issues I can't test this myself... Could someone please try this before merging?